### PR TITLE
Transaction: Remove duplication of MRID format

### DIFF
--- a/source/shared/messaging/source/GreenEnergyHub.Messaging/MessageTypes/Common/Transaction.cs
+++ b/source/shared/messaging/source/GreenEnergyHub.Messaging/MessageTypes/Common/Transaction.cs
@@ -32,7 +32,7 @@ namespace GreenEnergyHub.Messaging.MessageTypes.Common
         public string MRID { get; set; }
 
         public static Transaction NewTransaction()
-            => new Transaction(Guid.NewGuid().ToString("N"));
+            => new Transaction();
 
         public override bool Equals(object? obj)
         {


### PR DESCRIPTION
## Description
Transaction: Remove duplication of MRID format

When instantiating a Transaction, the class provides 3 options;
- Default Ctor
- Ctor with mrId argument
- factory method

The default ctor and the factory method both specified a specific GUID format.
To ensure that we create transactions in the same format - despite how they are constructed, let the FactoryMethod use the default ctor.

ps: transactions created with a specified mrId can still differ as the transaction does not enforce any constraints here

## References


* #0000
