### PR TITLE
Add domain events dispatch handling

### DIFF
--- a/source/business-workflow/source/Energinet.DataHub.MarketRoles.Domain/SeedWork/Entity.cs
+++ b/source/business-workflow/source/Energinet.DataHub.MarketRoles.Domain/SeedWork/Entity.cs
@@ -18,19 +18,19 @@ namespace Energinet.DataHub.MarketRoles.Domain.SeedWork
 {
     public abstract class Entity
     {
-        private List<IDomainEvent>? _domainEvents;
+        private List<IDomainEvent> _domainEvents = new List<IDomainEvent>();
 
         /// <summary>
         /// Domain events occurred.
         /// </summary>
-        public IReadOnlyCollection<IDomainEvent>? DomainEvents => _domainEvents?.AsReadOnly();
+        public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
 
         /// <summary>
         /// Clears all recorded events
         /// </summary>
         public void ClearDomainEvents()
         {
-            _domainEvents?.Clear();
+            _domainEvents.Clear();
         }
 
         // /// <summary>
@@ -55,8 +55,6 @@ namespace Energinet.DataHub.MarketRoles.Domain.SeedWork
         /// <param name="domainEvent">Domain event.</param>
         protected void AddDomainEvent(IDomainEvent domainEvent)
         {
-            _domainEvents ??= new List<IDomainEvent>();
-
             _domainEvents.Add(domainEvent);
         }
     }

--- a/source/business-workflow/source/Energinet.DataHub.MarketRoles.Infrastructure/BusinessRequestProcessing/Pipeline/DomainEventsDispatcherBehaviour.cs
+++ b/source/business-workflow/source/Energinet.DataHub.MarketRoles.Infrastructure/BusinessRequestProcessing/Pipeline/DomainEventsDispatcherBehaviour.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Energinet.DataHub.MarketRoles.Infrastructure.DomainEventDispatching;
+using MediatR;
+
+namespace Energinet.DataHub.MarketRoles.Infrastructure.BusinessRequestProcessing.Pipeline
+{
+    public class DomainEventsDispatcherBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+        where TRequest : IRequest<TResponse>
+    {
+        private readonly IDomainEventsDispatcher _domainEventsDispatcher;
+
+        public DomainEventsDispatcherBehaviour(IDomainEventsDispatcher domainEventsDispatcher)
+        {
+            _domainEventsDispatcher = domainEventsDispatcher ?? throw new ArgumentNullException(nameof(domainEventsDispatcher));
+        }
+
+        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        {
+            if (next == null) throw new ArgumentNullException(nameof(next));
+
+            var result = await next().ConfigureAwait(false);
+            await _domainEventsDispatcher.DispatchDomainEventsAsync().ConfigureAwait(false);
+            return result;
+        }
+    }
+}

--- a/source/business-workflow/source/Energinet.DataHub.MarketRoles.Infrastructure/DomainEventDispatching/DomainEventsAccessor.cs
+++ b/source/business-workflow/source/Energinet.DataHub.MarketRoles.Infrastructure/DomainEventDispatching/DomainEventsAccessor.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Energinet.DataHub.MarketRoles.Domain.SeedWork;
+using Energinet.DataHub.MarketRoles.Infrastructure.DataAccess;
+
+namespace Energinet.DataHub.MarketRoles.Infrastructure.DomainEventDispatching
+{
+    public class DomainEventsAccessor : IDomainEventsAccessor
+    {
+        private readonly MarketRolesContext _context;
+
+        public DomainEventsAccessor(MarketRolesContext context)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        public IReadOnlyCollection<IDomainEvent> GetAllDomainEvents()
+        {
+            var domainEvents = _context.ChangeTracker
+                .Entries<Entity>()
+                .SelectMany(x => x.Entity.DomainEvents)
+                .ToList();
+
+            return domainEvents;
+        }
+
+        public void ClearAllDomainEvents()
+        {
+            _context.ChangeTracker
+                .Entries<Entity>()
+                .ToList()
+                .ForEach(e => e.Entity.ClearDomainEvents());
+        }
+    }
+}

--- a/source/business-workflow/source/Energinet.DataHub.MarketRoles.Infrastructure/DomainEventDispatching/DomainEventsDispatcher.cs
+++ b/source/business-workflow/source/Energinet.DataHub.MarketRoles.Infrastructure/DomainEventDispatching/DomainEventsDispatcher.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using MediatR;
+
+namespace Energinet.DataHub.MarketRoles.Infrastructure.DomainEventDispatching
+{
+    public class DomainEventsDispatcher : IDomainEventsDispatcher
+    {
+        private readonly IDomainEventsAccessor _domainEventsAccessor;
+        private readonly IMediator _mediator;
+
+        public DomainEventsDispatcher(IDomainEventsAccessor domainEventsAccessor, IMediator mediator)
+        {
+            _domainEventsAccessor = domainEventsAccessor ?? throw new ArgumentNullException(nameof(domainEventsAccessor));
+            _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        }
+
+        public async Task DispatchDomainEventsAsync()
+        {
+            var domainEvents = _domainEventsAccessor.GetAllDomainEvents();
+            foreach (var domainEvent in domainEvents)
+            {
+                await _mediator.Publish(domainEvent).ConfigureAwait(false);
+            }
+
+            _domainEventsAccessor.ClearAllDomainEvents();
+        }
+    }
+}

--- a/source/business-workflow/source/Energinet.DataHub.MarketRoles.Infrastructure/DomainEventDispatching/IDomainEventsAccessor.cs
+++ b/source/business-workflow/source/Energinet.DataHub.MarketRoles.Infrastructure/DomainEventDispatching/IDomainEventsAccessor.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Energinet.DataHub.MarketRoles.Domain.SeedWork;
+
+namespace Energinet.DataHub.MarketRoles.Infrastructure.DomainEventDispatching
+{
+    /// <summary>
+    /// Provides access to all generated domain events in the current business process scope
+    /// </summary>
+    public interface IDomainEventsAccessor
+    {
+        /// <summary>
+        /// Returns all generated domain events
+        /// </summary>
+        /// <returns><see cref="IReadOnlyCollection{T}"/></returns>
+        IReadOnlyCollection<IDomainEvent> GetAllDomainEvents();
+
+        /// <summary>
+        /// Clears all generated domain events
+        /// </summary>
+        void ClearAllDomainEvents();
+    }
+}

--- a/source/business-workflow/source/Energinet.DataHub.MarketRoles.Infrastructure/DomainEventDispatching/IDomainEventsDispatcher.cs
+++ b/source/business-workflow/source/Energinet.DataHub.MarketRoles.Infrastructure/DomainEventDispatching/IDomainEventsDispatcher.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+
+namespace Energinet.DataHub.MarketRoles.Infrastructure.DomainEventDispatching
+{
+    /// <summary>
+    /// Service for dispatching all domain events generated during current domain process
+    /// </summary>
+    public interface IDomainEventsDispatcher
+    {
+        /// <summary>
+        /// Dispatches all generated domain events
+        /// </summary>
+        /// <returns><see cref="Task"/></returns>
+        Task DispatchDomainEventsAsync();
+    }
+}

--- a/source/business-workflow/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/TestHost.cs
+++ b/source/business-workflow/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/TestHost.cs
@@ -65,6 +65,7 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
             services.AddSingleton<IOutboxMessageFactory, OutboxMessageFactory>();
             services.AddScoped<ICommandScheduler, CommandScheduler>();
             services.AddScoped<IDomainEventsAccessor, DomainEventsAccessor>();
+            services.AddScoped<IDomainEventsDispatcher, DomainEventsDispatcher>();
 
             services.AddMediatR(new[]
             {

--- a/source/business-workflow/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/TestHost.cs
+++ b/source/business-workflow/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/TestHost.cs
@@ -78,6 +78,7 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
             // Business process pipeline
             services.AddScoped(typeof(IPipelineBehavior<,>), typeof(UnitOfWorkBehaviour<,>));
             services.AddScoped(typeof(IPipelineBehavior<,>), typeof(AuthorizationBehaviour<,>));
+            services.AddScoped(typeof(IPipelineBehavior<,>), typeof(DomainEventsDispatcherBehaviour<,>));
             services.AddScoped(typeof(IPipelineBehavior<,>), typeof(BusinessProcessResponderBehaviour<,>));
 
             ServiceProvider = services.BuildServiceProvider();

--- a/source/business-workflow/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/TestHost.cs
+++ b/source/business-workflow/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/TestHost.cs
@@ -30,6 +30,7 @@ using Energinet.DataHub.MarketRoles.Infrastructure.DataAccess.AccountingPoints;
 using Energinet.DataHub.MarketRoles.Infrastructure.DataAccess.Consumers;
 using Energinet.DataHub.MarketRoles.Infrastructure.DataAccess.EnergySuppliers;
 using Energinet.DataHub.MarketRoles.Infrastructure.DataAccess.ProcessManagers;
+using Energinet.DataHub.MarketRoles.Infrastructure.DomainEventDispatching;
 using Energinet.DataHub.MarketRoles.Infrastructure.EDIMessaging.ENTSOE.CIM.ChangeOfSupplier;
 using Energinet.DataHub.MarketRoles.Infrastructure.InternalCommands;
 using Energinet.DataHub.MarketRoles.Infrastructure.Outbox;
@@ -63,6 +64,7 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
             services.AddScoped<IOutbox, OutboxProvider>();
             services.AddSingleton<IOutboxMessageFactory, OutboxMessageFactory>();
             services.AddScoped<ICommandScheduler, CommandScheduler>();
+            services.AddScoped<IDomainEventsAccessor, DomainEventsAccessor>();
 
             services.AddMediatR(new[]
             {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description

This PR adds handling for domain events disparching and contains the following:

- `IDomainEventsAccessor` which enables fetching all generated domain events from the current business process scope
- `IDomainEventsDispatcher` used for dispatching domain events of to MediatR. Thus, `INotificationHandler`s are getting invoked.
- `DomainEventsDispatcherBehaviour` used for invoking `DomainEventsDispatcher` as the last step in a business process.

