### PR TITLE
limit dependabot to zero pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,48 +8,58 @@ updates:
     directory: "/source/business-workflow/source/Energinet.DataHub.MarketRoles.IntegrationTests"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "nuget"
     directory: "/source/business-workflow/source/Energinet.DataHub.MarketRoles.Application"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "nuget"
     directory: "/source/business-workflow/source/Energinet.DataHub.MarketRoles.ApplyDBMigrationsApp"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "nuget"
     directory: "/source/business-workflow/source/Energinet.DataHub.MarketRoles.Domain"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "nuget"
     directory: "/source/business-workflow/source/Energinet.DataHub.MarketRoles.EntryPoints.Common"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "nuget"
     directory: "/source/business-workflow/source/Energinet.DataHub.MarketRoles.EntryPoints.Ingestion"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "nuget"
     directory: "/source/business-workflow/source/Energinet.DataHub.MarketRoles.EntryPoints.Outbox"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "nuget"
     directory: "/source/business-workflow/source/Energinet.DataHub.MarketRoles.EntryPoints.Processing"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "nuget"
     directory: "/source/business-workflow/source/Energinet.DataHub.MarketRoles.Infrastructure"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "nuget"
     directory: "/source/business-workflow/source/Energinet.DataHub.MarketRoles.Tests"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
While we limit dependabot to zero pull requests, it will still be able to create security updates as these have their own internal limits (10).