### PR TITLE
Move analyze settings from csproj to common props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,10 @@
 <Project>
     <PropertyGroup>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+        <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <!--
     Add stylecop for all projects (so long as they don't override Directory.Build.props) with a common ruleset.
@@ -10,10 +14,7 @@
         <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.10.56" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
-		      <PrivateAssets>All</PrivateAssets>
-		      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	      </PackageReference>
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" />
 
         <!--
         Additional settings for specific rules (e.g. SA1200 specify namespaces must be placed correctly, the json file then defines what "correctly" means)

--- a/source/Energinet.DataHub.MarketRoles.Application/Energinet.DataHub.MarketRoles.Application.csproj
+++ b/source/Energinet.DataHub.MarketRoles.Application/Energinet.DataHub.MarketRoles.Application.csproj
@@ -17,10 +17,6 @@ limitations under the License.
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Energinet.DataHub.MarketRoles.ApplyDBMigrationsApp/Energinet.DataHub.MarketRoles.ApplyDBMigrationsApp.csproj
+++ b/source/Energinet.DataHub.MarketRoles.ApplyDBMigrationsApp/Energinet.DataHub.MarketRoles.ApplyDBMigrationsApp.csproj
@@ -19,10 +19,6 @@ limitations under the License.
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
-    <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Energinet.DataHub.MarketRoles.ApplyDBMigrationsApp</RootNamespace>
   </PropertyGroup>
 

--- a/source/Energinet.DataHub.MarketRoles.Domain/Energinet.DataHub.MarketRoles.Domain.csproj
+++ b/source/Energinet.DataHub.MarketRoles.Domain/Energinet.DataHub.MarketRoles.Domain.csproj
@@ -15,18 +15,14 @@ limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>9.0</LangVersion>
-        <Nullable>enable</Nullable>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-      </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="MediatR" Version="9.0.0" />
-      <PackageReference Include="NodaTime" Version="3.0.5" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MediatR" Version="9.0.0" />
+    <PackageReference Include="NodaTime" Version="3.0.5" />
+  </ItemGroup>
 
 </Project>

--- a/source/Energinet.DataHub.MarketRoles.Domain/MeteringPoints/Transaction.cs
+++ b/source/Energinet.DataHub.MarketRoles.Domain/MeteringPoints/Transaction.cs
@@ -26,9 +26,9 @@ namespace Energinet.DataHub.MarketRoles.Domain.MeteringPoints
 
         public string Value { get; set; }
 
-        public static Transaction Create(string transction)
+        public static Transaction Create(string transaction)
         {
-            return new Transaction(transction);
+            return new Transaction(transaction);
         }
 
         public override string ToString()

--- a/source/Energinet.DataHub.MarketRoles.EntryPoints.Common/Energinet.DataHub.MarketRoles.EntryPoints.Common.csproj
+++ b/source/Energinet.DataHub.MarketRoles.EntryPoints.Common/Energinet.DataHub.MarketRoles.EntryPoints.Common.csproj
@@ -17,10 +17,6 @@ limitations under the License.
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,5 +29,5 @@ limitations under the License.
   <ItemGroup>
     <ProjectReference Include="..\Energinet.DataHub.MarketRoles.Infrastructure\Energinet.DataHub.MarketRoles.Infrastructure.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/source/Energinet.DataHub.MarketRoles.EntryPoints.Ingestion/Energinet.DataHub.MarketRoles.EntryPoints.Ingestion.csproj
+++ b/source/Energinet.DataHub.MarketRoles.EntryPoints.Ingestion/Energinet.DataHub.MarketRoles.EntryPoints.Ingestion.csproj
@@ -20,10 +20,6 @@ limitations under the License.
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
-    <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.2.1" />

--- a/source/Energinet.DataHub.MarketRoles.EntryPoints.InternalCommandDispatcher/Dispatcher.cs
+++ b/source/Energinet.DataHub.MarketRoles.EntryPoints.InternalCommandDispatcher/Dispatcher.cs
@@ -32,7 +32,6 @@ namespace Energinet.DataHub.MarketRoles.EntryPoints.InternalCommandDispatcher
         [Function("Dispatcher")]
         public Task RunAsync([TimerTrigger("%DISPATCH_TRIGGER_TIMER%")] TimerInfo timerInfo, FunctionContext context)
         {
-            if (timerInfo == null) throw new ArgumentNullException(nameof(timerInfo));
             var logger = context.GetLogger("Dispatcher");
             logger.LogInformation($"Timer trigger function executed at: {DateTime.Now}");
             logger.LogInformation($"Next timer schedule at: {timerInfo?.ScheduleStatus?.Next}");

--- a/source/Energinet.DataHub.MarketRoles.EntryPoints.InternalCommandDispatcher/Energinet.DataHub.MarketRoles.EntryPoints.InternalCommandDispatcher.csproj
+++ b/source/Energinet.DataHub.MarketRoles.EntryPoints.InternalCommandDispatcher/Energinet.DataHub.MarketRoles.EntryPoints.InternalCommandDispatcher.csproj
@@ -14,36 +14,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-      <TargetFramework>net5.0</TargetFramework>
-      <LangVersion>preview</LangVersion>
-      <AzureFunctionsVersion>v3</AzureFunctionsVersion>
-      <OutputType>Exe</OutputType>
-      <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
-      <Nullable>enable</Nullable>
-      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-      <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-      <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.1.0" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.3" OutputItemType="Analyzer" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.3.0" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Update="host.json">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
-        <None Update="local.settings.json">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-        </None>
-    </ItemGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\Energinet.DataHub.MarketRoles.EntryPoints.Common\Energinet.DataHub.MarketRoles.EntryPoints.Common.csproj" />
-      <ProjectReference Include="..\Energinet.DataHub.MarketRoles.Infrastructure\Energinet.DataHub.MarketRoles.Infrastructure.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-      <Folder Include="Infrastructure" />
-    </ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+    <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.3" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.3.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Energinet.DataHub.MarketRoles.EntryPoints.Common\Energinet.DataHub.MarketRoles.EntryPoints.Common.csproj" />
+    <ProjectReference Include="..\Energinet.DataHub.MarketRoles.Infrastructure\Energinet.DataHub.MarketRoles.Infrastructure.csproj" />
+  </ItemGroup>
 </Project>

--- a/source/Energinet.DataHub.MarketRoles.EntryPoints.Outbox/Energinet.DataHub.MarketRoles.EntryPoints.Outbox.csproj
+++ b/source/Energinet.DataHub.MarketRoles.EntryPoints.Outbox/Energinet.DataHub.MarketRoles.EntryPoints.Outbox.csproj
@@ -16,14 +16,10 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
-    <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MediatR" Version="9.0.0" />

--- a/source/Energinet.DataHub.MarketRoles.EntryPoints.Processing/Energinet.DataHub.MarketRoles.EntryPoints.Processing.csproj
+++ b/source/Energinet.DataHub.MarketRoles.EntryPoints.Processing/Energinet.DataHub.MarketRoles.EntryPoints.Processing.csproj
@@ -16,14 +16,10 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
-    <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="5.0.1" />

--- a/source/Energinet.DataHub.MarketRoles.Infrastructure/EDI/MoveIn/RequestMoveInResultHandler.cs
+++ b/source/Energinet.DataHub.MarketRoles.Infrastructure/EDI/MoveIn/RequestMoveInResultHandler.cs
@@ -78,7 +78,7 @@ namespace Energinet.DataHub.MarketRoles.Infrastructure.EDI.MoveIn
                     MarketEvaluationPoint: request.AccountingPointGsrnNumber,
                     StartDateAndOrTime: request.MoveInDate,
                     OriginalTransaction: request.TransactionId,
-                    Reasons: new List<Reason> { new Reason("TODO", "TODO") })); // TODO: Use error conversion
+                    Reasons: errors.Select(error => new Reason(error.Code, error.Description)).ToList()));
 
             var document = AcknowledgementXmlSerializer.Serialize(message, XmlNamespace);
 

--- a/source/Energinet.DataHub.MarketRoles.Infrastructure/Energinet.DataHub.MarketRoles.Infrastructure.csproj
+++ b/source/Energinet.DataHub.MarketRoles.Infrastructure/Energinet.DataHub.MarketRoles.Infrastructure.csproj
@@ -18,10 +18,6 @@ limitations under the License.
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
-    <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/ChangeOfSupplier/Processing/Commands/ChangeSupplierTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/ChangeOfSupplier/Processing/Commands/ChangeSupplierTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Data;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,7 +42,7 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.ChangeOfSup
         private readonly Consumer _consumer;
         private readonly IMediator _mediator;
 
-        private Transaction _transaction = null;
+        private Transaction _transaction = CreateTransaction();
 
         public ChangeSupplierTests()
         {
@@ -54,15 +55,17 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.ChangeOfSup
         [Fact]
         public async Task ChangeSupplier_WhenEffectiveDateIsDue_IsSuccessful()
         {
-            await SimulateProcess();
+            await SimulateProcess().ConfigureAwait(false);
 
             var command = new ChangeSupplier(_accountingPoint.Id.Value, _transaction.Value);
-            await GetService<IMediator>().Send(command, CancellationToken.None);
+            await GetService<IMediator>().Send(command, CancellationToken.None).ConfigureAwait(false);
 
-            var query =
-                $"SELECT Count(1) FROM SupplierRegistrations WHERE AccountingPointId = '{_accountingPoint.Id.Value}' AND EnergySupplierId = '{_energySupplier.EnergySupplierId.Value}' AND StartOfSupplyDate IS NOT NULL AND EndOfSupplyDate IS NULL";
-            var sqlCommand = new SqlCommand(query, GetSqlDbConnection());
-            var result = await sqlCommand.ExecuteScalarAsync();
+            string query = @"SELECT Count(1) FROM SupplierRegistrations WHERE AccountingPointId = @AccountingPointId AND EnergySupplierId = @EnergySupplierId AND StartOfSupplyDate IS NOT NULL AND EndOfSupplyDate IS NULL";
+            await using var sqlCommand = new SqlCommand(query, GetSqlDbConnection());
+            sqlCommand.Parameters.Add("@AccountingPointId", SqlDbType.NVarChar).Value = Transaction.Value;
+            sqlCommand.Parameters.Add("@EnergySupplierId", SqlDbType.NVarChar).Value = Transaction.Value;
+
+            var result = await sqlCommand.ExecuteScalarAsync().ConfigureAwait(false);
 
             Assert.Equal(1, result);
         }
@@ -76,16 +79,16 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.ChangeOfSup
             await Mediator.Send(new RequestChangeOfSupplier(
                 _transaction.Value,
                 _energySupplier.GlnNumber.Value,
-                _consumer.CprNumber.Value,
+                _consumer.CprNumber?.Value ?? throw new InvalidOperationException("CprNumber was supposed to have a value"),
                 string.Empty,
                 _accountingPoint.GsrnNumber.Value,
-                Instant.FromDateTimeUtc(DateTime.UtcNow.AddHours(1)).ToString()));
+                Instant.FromDateTimeUtc(DateTime.UtcNow.AddHours(1)).ToString())).ConfigureAwait(false);
 
             var businessProcessId = GetBusinessProcessId(_transaction);
 
-            await Mediator.Send(new ForwardMeteringPointDetails(_accountingPoint.Id.Value, businessProcessId.Value, _transaction.Value));
-            await Mediator.Send(new ForwardConsumerDetails(_accountingPoint.Id.Value, businessProcessId.Value, _transaction.Value));
-            await Mediator.Send(new NotifyCurrentSupplier(_accountingPoint.Id.Value, businessProcessId.Value, _transaction.Value));
+            await Mediator.Send(new ForwardMeteringPointDetails(_accountingPoint.Id.Value, businessProcessId.Value, _transaction.Value)).ConfigureAwait(false);
+            await Mediator.Send(new ForwardConsumerDetails(_accountingPoint.Id.Value, businessProcessId.Value, _transaction.Value)).ConfigureAwait(false);
+            await Mediator.Send(new NotifyCurrentSupplier(_accountingPoint.Id.Value, businessProcessId.Value, _transaction.Value)).ConfigureAwait(false);
         }
     }
 }

--- a/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/ChangeOfSupplier/Processing/ProcessManagerRouterTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/ChangeOfSupplier/Processing/ProcessManagerRouterTests.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Energinet.DataHub.MarketRoles.Application.ChangeOfSupplier.Processing;
@@ -24,10 +22,6 @@ using Energinet.DataHub.MarketRoles.Domain.Consumers;
 using Energinet.DataHub.MarketRoles.Domain.EnergySuppliers;
 using Energinet.DataHub.MarketRoles.Domain.MeteringPoints;
 using Energinet.DataHub.MarketRoles.Domain.MeteringPoints.Events;
-using Energinet.DataHub.MarketRoles.Infrastructure.InternalCommands;
-using Energinet.DataHub.MarketRoles.Infrastructure.Transport;
-using Energinet.DataHub.MarketRoles.Infrastructure.Transport.Protobuf;
-using Microsoft.EntityFrameworkCore;
 using Xunit;
 using Xunit.Categories;
 
@@ -61,86 +55,86 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.ChangeOfSup
         [Fact]
         public async Task EnergySupplierChangeIsRegistered_WhenStateIsNotStarted_ForwardMasterDataDetailsCommandIsEnqueued()
         {
-            await _router.Handle(CreateSupplierChangeRegisteredEvent(), CancellationToken.None);
-            await UnitOfWork.CommitAsync();
+            await _router.Handle(CreateSupplierChangeRegisteredEvent(), CancellationToken.None).ConfigureAwait(false);
+            await UnitOfWork.CommitAsync().ConfigureAwait(false);
 
-            var command = await GetEnqueuedCommandAsync<ForwardMeteringPointDetails>();
+            var command = await GetEnqueuedCommandAsync<ForwardMeteringPointDetails>().ConfigureAwait(false);
 
             Assert.NotNull(command);
-            Assert.Equal(_businessProcessId.Value, command.BusinessProcessId);
+            Assert.Equal(_businessProcessId.Value, command?.BusinessProcessId);
         }
 
         [Fact]
         public async Task MeteringPointDetailsAreDispatched_WhenStateIsAwaitingMeteringPointDetailsDispatch_ForwardConsumerDetailsCommandIsEnqueued()
         {
-            await _router.Handle(CreateSupplierChangeRegisteredEvent(), CancellationToken.None);
-            await UnitOfWork.CommitAsync();
+            await _router.Handle(CreateSupplierChangeRegisteredEvent(), CancellationToken.None).ConfigureAwait(false);
+            await UnitOfWork.CommitAsync().ConfigureAwait(false);
 
             await _router.Handle(new MeteringPointDetailsDispatched(_accountingPoint.Id, _businessProcessId, Transaction), CancellationToken.None).ConfigureAwait(false);
-            await UnitOfWork.CommitAsync();
+            await UnitOfWork.CommitAsync().ConfigureAwait(false);
 
-            var command = await GetEnqueuedCommandAsync<ForwardConsumerDetails>();
+            var command = await GetEnqueuedCommandAsync<ForwardConsumerDetails>().ConfigureAwait(false);
             Assert.NotNull(command);
-            Assert.Equal(_businessProcessId.Value, command.BusinessProcessId);
+            Assert.Equal(_businessProcessId.Value, command?.BusinessProcessId);
         }
 
         [Fact]
         public async Task ConsumerDetailsAreDispatched_WhenStateIsAwaitingConsumerDetailsDispatch_NotifyCurrentSupplierCommandIsEnqueued()
         {
-            await _router.Handle(CreateSupplierChangeRegisteredEvent(), CancellationToken.None);
-            await UnitOfWork.CommitAsync();
+            await _router.Handle(CreateSupplierChangeRegisteredEvent(), CancellationToken.None).ConfigureAwait(false);
+            await UnitOfWork.CommitAsync().ConfigureAwait(false);
 
             await _router.Handle(new MeteringPointDetailsDispatched(_accountingPoint.Id, _businessProcessId, Transaction), CancellationToken.None).ConfigureAwait(false);
-            await UnitOfWork.CommitAsync();
+            await UnitOfWork.CommitAsync().ConfigureAwait(false);
 
             await _router.Handle(new ConsumerDetailsDispatched(_accountingPoint.Id, _businessProcessId, Transaction), CancellationToken.None).ConfigureAwait(false);
-            await UnitOfWork.CommitAsync();
+            await UnitOfWork.CommitAsync().ConfigureAwait(false);
 
-            var command = await GetEnqueuedCommandAsync<NotifyCurrentSupplier>();
+            var command = await GetEnqueuedCommandAsync<NotifyCurrentSupplier>().ConfigureAwait(false);
             Assert.NotNull(command);
-            Assert.Equal(_businessProcessId.Value, command.BusinessProcessId);
+            Assert.Equal(_businessProcessId.Value, command?.BusinessProcessId);
         }
 
         [Fact]
         public async Task CurrentSupplierIsNotified_WhenStateIsAwaitingCurrentSupplierNotification_ChangeSupplierCommandIsScheduled()
         {
-            await _router.Handle(CreateSupplierChangeRegisteredEvent(), CancellationToken.None);
-            await UnitOfWork.CommitAsync();
+            await _router.Handle(CreateSupplierChangeRegisteredEvent(), CancellationToken.None).ConfigureAwait(false);
+            await UnitOfWork.CommitAsync().ConfigureAwait(false);
 
             await _router.Handle(new MeteringPointDetailsDispatched(_accountingPoint.Id, _businessProcessId, Transaction), CancellationToken.None).ConfigureAwait(false);
-            await UnitOfWork.CommitAsync();
+            await UnitOfWork.CommitAsync().ConfigureAwait(false);
 
             await _router.Handle(new ConsumerDetailsDispatched(_accountingPoint.Id, _businessProcessId, Transaction), CancellationToken.None).ConfigureAwait(false);
-            await UnitOfWork.CommitAsync();
+            await UnitOfWork.CommitAsync().ConfigureAwait(false);
 
             await _router.Handle(new CurrentSupplierNotified(_accountingPoint.Id, _businessProcessId, Transaction), CancellationToken.None).ConfigureAwait(false);
-            await UnitOfWork.CommitAsync();
+            await UnitOfWork.CommitAsync().ConfigureAwait(false);
 
-            var command = await GetEnqueuedCommandAsync<ChangeSupplier>();
+            var command = await GetEnqueuedCommandAsync<ChangeSupplier>().ConfigureAwait(false);
             Assert.NotNull(command);
-            Assert.Equal(_accountingPoint.Id.Value, command.AccountingPointId);
+            Assert.Equal(_accountingPoint.Id.Value, command?.AccountingPointId);
         }
 
         [Fact]
         public async Task SupplierIsChanged_WhenStateIsAwaitingSupplierChange_ProcessIsCompleted()
         {
-            await _router.Handle(CreateSupplierChangeRegisteredEvent(), CancellationToken.None);
-            await UnitOfWork.CommitAsync();
+            await _router.Handle(CreateSupplierChangeRegisteredEvent(), CancellationToken.None).ConfigureAwait(false);
+            await UnitOfWork.CommitAsync().ConfigureAwait(false);
 
             await _router.Handle(new MeteringPointDetailsDispatched(_accountingPoint.Id, _businessProcessId, Transaction), CancellationToken.None).ConfigureAwait(false);
-            await UnitOfWork.CommitAsync();
+            await UnitOfWork.CommitAsync().ConfigureAwait(false);
 
             await _router.Handle(new ConsumerDetailsDispatched(_accountingPoint.Id, _businessProcessId, Transaction), CancellationToken.None).ConfigureAwait(false);
-            await UnitOfWork.CommitAsync();
+            await UnitOfWork.CommitAsync().ConfigureAwait(false);
 
             await _router.Handle(new CurrentSupplierNotified(_accountingPoint.Id, _businessProcessId, Transaction), CancellationToken.None).ConfigureAwait(false);
-            await UnitOfWork.CommitAsync();
+            await UnitOfWork.CommitAsync().ConfigureAwait(false);
 
             await _router.Handle(CreateEnergySupplierChangedEvent(), CancellationToken.None).ConfigureAwait(false);
-            await UnitOfWork.CommitAsync();
+            await UnitOfWork.CommitAsync().ConfigureAwait(false);
 
-            var processManager = await ProcessManagerRepository.GetAsync<ChangeOfSupplierProcessManager>(_businessProcessId);
-            Assert.True(processManager.IsCompleted());
+            var processManager = await ProcessManagerRepository.GetAsync<ChangeOfSupplierProcessManager>(_businessProcessId).ConfigureAwait(false);
+            Assert.True(processManager?.IsCompleted());
         }
 
         private EnergySupplierChangeRegistered CreateSupplierChangeRegisteredEvent()

--- a/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/ChangeOfSupplier/RequestTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/ChangeOfSupplier/RequestTests.cs
@@ -42,7 +42,7 @@ using Xunit.Categories;
 namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.ChangeOfSupplier
 {
     [IntegrationTest]
-    public sealed class RequestTests : TestHost, IDisposable
+    public sealed class RequestTests : TestHost
     {
         [Fact]
         public async Task Request_WhenMeteringPointDoesNotExist_IsRejected()
@@ -101,17 +101,7 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.ChangeOfSup
             Assert.Equal(request.AccountingPointGsrnNumber, publishedMessage.AccountingPointId);
         }
 
-        private RequestChangeOfSupplier CreateRequest()
-        {
-            return CreateRequest(
-                SampleData.Transaction,
-                SampleData.GlnNumber,
-                SampleData.ConsumerSSN,
-                SampleData.GsrnNumber,
-                Instant.FromDateTimeUtc(DateTime.UtcNow.AddHours(1)).ToString());
-        }
-
-        private RequestChangeOfSupplier CreateRequest(string transaction, string energySupplierGln, string consumerId, string gsrnNumber, string startDate)
+        private static RequestChangeOfSupplier CreateRequest(string transaction, string energySupplierGln, string consumerId, string gsrnNumber, string startDate)
         {
             return new RequestChangeOfSupplier(
                 TransactionId: transaction,
@@ -119,6 +109,16 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.ChangeOfSup
                 SocialSecurityNumber: consumerId,
                 AccountingPointGsrnNumber: gsrnNumber,
                 StartDate: startDate);
+        }
+
+        private static RequestChangeOfSupplier CreateRequest()
+        {
+            return CreateRequest(
+                SampleData.Transaction,
+                SampleData.GlnNumber,
+                SampleData.ConsumerSSN,
+                SampleData.GsrnNumber,
+                Instant.FromDateTimeUtc(DateTime.UtcNow.AddHours(1)).ToString());
         }
     }
 }

--- a/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/MoveIn/EffectuateTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/MoveIn/EffectuateTests.cs
@@ -29,12 +29,12 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.MoveIn
         [Fact]
         public async Task Effectuate_WhenEffectiveDateIsDue_IntegrationEventsArePublished()
         {
-            var (accountingPoint, transaction) = await SetupScenarioAsync();
+            var (accountingPoint, transaction) = await SetupScenarioAsync().ConfigureAwait(false);
             var command = new EffectuateConsumerMoveIn(accountingPoint.Id.Value, transaction.Value);
 
-            await InvokeCommandAsync(command);
+            await InvokeCommandAsync(command).ConfigureAwait(false);
 
-            await AssertOutboxMessageAsync<EnergySupplierChangedIntegrationEvent>();
+            await AssertOutboxMessageAsync<EnergySupplierChangedIntegrationEvent>().ConfigureAwait(false);
         }
 
         private async Task<(AccountingPoint AccountingPoint, Transaction Transaction)> SetupScenarioAsync()
@@ -53,7 +53,7 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.MoveIn
                 SampleData.GsrnNumber,
                 SampleData.MoveInDate);
 
-            var result = await SendRequest(requestMoveIn);
+            var result = await SendRequestAsync(requestMoveIn).ConfigureAwait(false);
 
             return (accountingPoint, Transaction.Create(result.TransactionId));
         }

--- a/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/MoveIn/MoveInTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/MoveIn/MoveInTests.cs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Threading.Tasks;
 using Energinet.DataHub.MarketRoles.Application.MoveIn;
 using Energinet.DataHub.MarketRoles.Domain.Consumers;
-using Energinet.DataHub.MarketRoles.Domain.MeteringPoints;
 using Energinet.DataHub.MarketRoles.Domain.SeedWork;
 using Energinet.DataHub.MarketRoles.Infrastructure.EDI;
 using Xunit;
@@ -26,12 +26,6 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.MoveIn
     [IntegrationTest]
     public class MoveInTests : TestHost
     {
-        private readonly AccountingPoint _accountingPoint;
-
-        public MoveInTests()
-        {
-        }
-
         [Fact]
         public async Task Accept_WhenConsumerIsRegistered_AcceptMessageIsPublished()
         {
@@ -41,10 +35,10 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.MoveIn
 
             var request = CreateRequest();
 
-            var result = await SendRequest(request);
+            var result = await SendRequestAsync(request).ConfigureAwait(false);
 
             Assert.True(result.Success);
-            await AssertOutboxMessageAsync<PostOfficeEnvelope>(envelope => envelope.MessageType.StartsWith("Confirm"))
+            await AssertOutboxMessageAsync<PostOfficeEnvelope>(envelope => envelope.MessageType.StartsWith("Confirm", StringComparison.Ordinal))
                 .ConfigureAwait(false);
         }
 
@@ -56,10 +50,10 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.MoveIn
 
             var request = CreateRequest();
 
-            var result = await SendRequest(request);
+            var result = await SendRequestAsync(request).ConfigureAwait(false);
 
             Assert.False(result.Success);
-            await AssertOutboxMessageAsync<PostOfficeEnvelope>(envelope => envelope.MessageType.StartsWith("Reject"))
+            await AssertOutboxMessageAsync<PostOfficeEnvelope>(envelope => envelope.MessageType.StartsWith("Reject", StringComparison.Ordinal))
                 .ConfigureAwait(false);
         }
 
@@ -71,10 +65,10 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.MoveIn
 
             var request = CreateRequest();
 
-            var result = await SendRequest(request);
+            var result = await SendRequestAsync(request).ConfigureAwait(false);
 
             Assert.False(result.Success);
-            await AssertOutboxMessageAsync<PostOfficeEnvelope>(envelope => envelope.MessageType.StartsWith("Reject"))
+            await AssertOutboxMessageAsync<PostOfficeEnvelope>(envelope => envelope.MessageType.StartsWith("Reject", StringComparison.Ordinal))
                 .ConfigureAwait(false);
         }
 
@@ -86,9 +80,9 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.MoveIn
             SaveChanges();
 
             var request = CreateRequest();
-            await SendRequest(request);
+            await SendRequestAsync(request).ConfigureAwait(false);
 
-            var consumer = await GetService<IConsumerRepository>().GetBySSNAsync(CprNumber.Create(request.SocialSecurityNumber));
+            var consumer = await GetService<IConsumerRepository>().GetBySSNAsync(CprNumber.Create(request.SocialSecurityNumber)).ConfigureAwait(false);
             Assert.NotNull(consumer);
         }
 
@@ -100,9 +94,9 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.MoveIn
             SaveChanges();
 
             var request = CreateRequest(false);
-            await SendRequest(request);
+            await SendRequestAsync(request).ConfigureAwait(false);
 
-            var consumer = await GetService<IConsumerRepository>().GetByVATNumberAsync(CvrNumber.Create(request.VATNumber));
+            var consumer = await GetService<IConsumerRepository>().GetByVATNumberAsync(CvrNumber.Create(request.VATNumber)).ConfigureAwait(false);
             Assert.NotNull(consumer);
         }
 

--- a/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/MoveIn/Processing/MoveInProcessManagerTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/MoveIn/Processing/MoveInProcessManagerTests.cs
@@ -38,27 +38,27 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.MoveIn.Proc
         [Fact]
         public async Task ConsumerMoveInAccepted_WhenStateIsNotStarted_EffectuateCommandIsEnqueued()
         {
-            var (transaction, businessProcessId) = await SetupScenario();
+            var (transaction, businessProcessId) = await SetupScenario().ConfigureAwait(false);
 
-            var command = await GetEnqueuedCommandAsync<EffectuateConsumerMoveIn>(businessProcessId);
+            var command = await GetEnqueuedCommandAsync<EffectuateConsumerMoveIn>(businessProcessId).ConfigureAwait(false);
 
             Assert.NotNull(command);
-            Assert.Equal(transaction.Value, command.Transaction);
+            Assert.Equal(transaction.Value, command?.Transaction);
         }
 
         [Fact]
         public async Task ConsumerMoveIn_WhenStateIsAwaitingEffectuation_ProcessIsCompleted()
         {
-            var (_, businessProcessId) = await SetupScenario();
+            var (_, businessProcessId) = await SetupScenario().ConfigureAwait(false);
 
-            var effectuateConsumerMoveInCommand = await GetEnqueuedCommandAsync<EffectuateConsumerMoveIn>(businessProcessId);
-            await InvokeCommandAsync(effectuateConsumerMoveInCommand);
+            var effectuateConsumerMoveInCommand = await GetEnqueuedCommandAsync<EffectuateConsumerMoveIn>(businessProcessId).ConfigureAwait(false);
+            await InvokeCommandAsync(effectuateConsumerMoveInCommand!).ConfigureAwait(false);
 
-            var processManager = await ProcessManagerRepository.GetAsync<MoveInProcessManager>(businessProcessId);
-            Assert.True(processManager.IsCompleted());
+            var processManager = await ProcessManagerRepository.GetAsync<MoveInProcessManager>(businessProcessId).ConfigureAwait(false);
+            Assert.True(processManager?.IsCompleted());
         }
 
-        private async Task<(Transaction, BusinessProcessId)> SetupScenario()
+        private async Task<(Transaction Transaction, BusinessProcessId BusinessProcessId)> SetupScenario()
         {
             _ = CreateAccountingPoint();
             _ = CreateEnergySupplier();
@@ -66,16 +66,15 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application.MoveIn.Proc
             SaveChanges();
 
             var transaction = CreateTransaction();
-            var moveInDate = GetService<ISystemDateTimeProvider>().Now();
 
-            await SendRequest(new RequestMoveIn(
+            await SendRequestAsync(new RequestMoveIn(
                 transaction.Value,
                 SampleData.GlnNumber,
                 SampleData.ConsumerSSN,
                 string.Empty,
                 SampleData.ConsumerName,
                 SampleData.GsrnNumber,
-                SampleData.MoveInDate));
+                SampleData.MoveInDate)).ConfigureAwait(false);
 
             return (transaction, GetBusinessProcessId(transaction));
         }

--- a/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/TestHost.cs
+++ b/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/TestHost.cs
@@ -72,13 +72,14 @@ using RequestMoveIn = Energinet.DataHub.MarketRoles.Application.MoveIn.RequestMo
 namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
 {
     [Collection("IntegrationTest")]
+#pragma warning disable CA1724 // TODO: TestHost is reserved. Maybe refactor to base EntryPoint?
     public class TestHost : IDisposable
     {
         private readonly Scope _scope;
         private readonly Container _container;
-        private readonly IServiceProvider _serviceProvider;
-        private SqlConnection _sqlConnection = null;
-        private BusinessProcessId _businessProcessId = null;
+        private bool _disposed;
+        private SqlConnection? _sqlConnection;
+        private BusinessProcessId? _businessProcessId;
 
         protected TestHost()
         {
@@ -96,7 +97,7 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
             serviceCollection.AddDbContext<MarketRolesContext>(x =>
                 x.UseSqlServer(ConnectionString, y => y.UseNodaTime()));
             serviceCollection.AddSimpleInjector(_container);
-            _serviceProvider = serviceCollection.BuildServiceProvider().UseSimpleInjector(_container);
+            IServiceProvider serviceProvider = serviceCollection.BuildServiceProvider().UseSimpleInjector(_container);
 
             _container.Register<IUnitOfWork, UnitOfWork>(Lifestyle.Scoped);
             _container.Register<IAccountingPointRepository, AccountingPointRepository>(Lifestyle.Scoped);
@@ -156,17 +157,17 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
 
             CleanupDatabase();
 
-            ServiceProvider = _serviceProvider;
-            Mediator = _container.GetService<IMediator>();
-            AccountingPointRepository = _container.GetService<IAccountingPointRepository>();
-            EnergySupplierRepository = _container.GetService<IEnergySupplierRepository>();
-            ProcessManagerRepository = _container.GetService<IProcessManagerRepository>();
-            ConsumerRepository = _container.GetService<IConsumerRepository>();
-            UnitOfWork = _container.GetService<IUnitOfWork>();
-            MarketRolesContext = _container.GetService<MarketRolesContext>();
-            SystemDateTimeProvider = _container.GetService<ISystemDateTimeProvider>();
-            Serializer = _container.GetService<IJsonSerializer>();
-            CommandScheduler = _container.GetService<ICommandScheduler>();
+            ServiceProvider = serviceProvider;
+            Mediator = _container.GetInstance<IMediator>();
+            AccountingPointRepository = _container.GetInstance<IAccountingPointRepository>();
+            EnergySupplierRepository = _container.GetInstance<IEnergySupplierRepository>();
+            ProcessManagerRepository = _container.GetInstance<IProcessManagerRepository>();
+            ConsumerRepository = _container.GetInstance<IConsumerRepository>();
+            UnitOfWork = _container.GetInstance<IUnitOfWork>();
+            MarketRolesContext = _container.GetInstance<MarketRolesContext>();
+            SystemDateTimeProvider = _container.GetInstance<ISystemDateTimeProvider>();
+            Serializer = _container.GetInstance<IJsonSerializer>();
+            CommandScheduler = _container.GetInstance<ICommandScheduler>();
             Transaction = new Transaction(Guid.NewGuid().ToString());
         }
 
@@ -197,17 +198,41 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
 
         protected Instant EffectiveDate => SystemDateTimeProvider.Now();
 
-        private string ConnectionString =>
-            Environment.GetEnvironmentVariable("MarketRoles_IntegrationTests_ConnectionString");
+        private static string ConnectionString =>
+            Environment.GetEnvironmentVariable("MarketRoles_IntegrationTests_ConnectionString")
+            ?? throw new InvalidOperationException("MarketRoles_IntegrationTests_ConnectionString config not set");
 
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected static Transaction CreateTransaction()
+        {
+            return new Transaction(Guid.NewGuid().ToString());
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
             CleanupDatabase();
+
+            _sqlConnection?.Dispose();
+            _scope.Dispose();
+            _container.Dispose();
+
+            _disposed = true;
         }
 
         protected TService GetService<TService>()
+            where TService : class
         {
-            return _container.GetService<TService>();
+            return _container.GetInstance<TService>();
         }
 
         protected SqlConnection GetSqlDbConnection()
@@ -232,14 +257,16 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
 
         protected async Task<TMessage> GetLastMessageFromOutboxAsync<TMessage>()
         {
+#pragma warning disable CA1309 // Warns about: "Use ordinal string comparison", but we want EF to take care of this.
             var outboxMessage = await MarketRolesContext.OutboxMessages.FirstAsync(m => m.Type.Equals(typeof(TMessage).FullName)).ConfigureAwait(false);
+            #pragma warning restore CA1309
             var @event = Serializer.Deserialize<TMessage>(outboxMessage.Data);
             return @event;
         }
 
-        protected async Task<BusinessProcessResult> SendRequest(IBusinessRequest request)
+        protected async Task<BusinessProcessResult> SendRequestAsync(IBusinessRequest request)
         {
-            var result = await GetService<IMediator>().Send(request, CancellationToken.None);
+            var result = await GetService<IMediator>().Send(request, CancellationToken.None).ConfigureAwait(false);
             return result;
         }
 
@@ -248,12 +275,14 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
             return GetService<IMediator>().Send(command, CancellationToken.None);
         }
 
-        protected async Task<TCommand> GetEnqueuedCommandAsync<TCommand>()
+        protected async Task<TCommand?> GetEnqueuedCommandAsync<TCommand>()
         {
+            var businessProcessId = _businessProcessId?.Value ?? throw new InvalidOperationException("Unknown BusinessProcessId");
             var type = typeof(TCommand).FullName;
             var queuedCommand = MarketRolesContext.QueuedInternalCommands
                 .FirstOrDefault(queuedInternalCommand =>
-                    queuedInternalCommand.BusinessProcessId.Equals(_businessProcessId.Value) &&
+                    queuedInternalCommand.BusinessProcessId.Equals(businessProcessId) &&
+#pragma warning disable CA1309 // Warns about: "Use ordinal string comparison", but we want EF to take care of this.
                     queuedInternalCommand.Type.Equals(type));
 
             if (queuedCommand is null)
@@ -266,12 +295,13 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
             return (TCommand)command;
         }
 
-        protected async Task<TCommand> GetEnqueuedCommandAsync<TCommand>(BusinessProcessId businessProcessId)
+        protected async Task<TCommand?> GetEnqueuedCommandAsync<TCommand>(BusinessProcessId businessProcessId)
         {
             var type = typeof(TCommand).FullName;
             var queuedCommand = MarketRolesContext.QueuedInternalCommands
                 .FirstOrDefault(queuedInternalCommand =>
                     queuedInternalCommand.BusinessProcessId.Equals(businessProcessId.Value) &&
+#pragma warning disable CA1309 // Warns about: "Use ordinal string comparison", but we want EF to take care of this.
                     queuedInternalCommand.Type.Equals(type));
 
             if (queuedCommand is null)
@@ -314,11 +344,6 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
             return meteringPoint;
         }
 
-        protected Transaction CreateTransaction()
-        {
-            return new Transaction(Guid.NewGuid().ToString());
-        }
-
         protected void SetConsumerMovedIn(AccountingPoint accountingPoint, ConsumerId consumerId, EnergySupplierId energySupplierId)
         {
             var systemTimeProvider = GetService<ISystemDateTimeProvider>();
@@ -329,6 +354,8 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
 
         protected void SetConsumerMovedIn(AccountingPoint accountingPoint, ConsumerId consumerId, EnergySupplierId energySupplierId, Instant moveInDate, Transaction transaction)
         {
+            if (accountingPoint == null) throw new ArgumentNullException(nameof(accountingPoint));
+
             var systemTimeProvider = GetService<ISystemDateTimeProvider>();
             accountingPoint.AcceptConsumerMoveIn(consumerId, energySupplierId, moveInDate, transaction);
             accountingPoint.EffectuateConsumerMoveIn(transaction, systemTimeProvider);
@@ -336,6 +363,8 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
 
         protected void RegisterChangeOfSupplier(AccountingPoint accountingPoint, ConsumerId consumerId, EnergySupplierId energySupplierId, Transaction transaction)
         {
+            if (accountingPoint == null) throw new ArgumentNullException(nameof(accountingPoint));
+
             var systemTimeProvider = GetService<ISystemDateTimeProvider>();
 
             var moveInDate = systemTimeProvider.Now().Minus(Duration.FromDays(365));
@@ -349,9 +378,10 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
         {
             if (_businessProcessId == null)
             {
-                var command = new SqlCommand($"SELECT Id FROM [dbo].[BusinessProcesses] WHERE TransactionId = '{Transaction.Value}'", GetSqlDbConnection());
-                var id = command.ExecuteScalar();
-                _businessProcessId = new BusinessProcessId(Guid.Parse(id.ToString()));
+                using var command = new SqlCommand($"SELECT Id FROM [dbo].[BusinessProcesses] WHERE TransactionId = @transaction", GetSqlDbConnection());
+                command.Parameters.Add("@transaction", SqlDbType.NVarChar).Value = Transaction.Value;
+                var id = (Guid)command.ExecuteScalar();
+                _businessProcessId = BusinessProcessId.Create(id);
             }
 
             return _businessProcessId;
@@ -359,17 +389,20 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
 
         protected BusinessProcessId GetBusinessProcessId(Transaction transaction)
         {
+            if (transaction == null) throw new ArgumentNullException(nameof(transaction));
+
             if (_businessProcessId == null)
             {
-                var connection = new SqlConnection(ConnectionString);
+                using var connection = new SqlConnection(ConnectionString);
                 if (connection.State == ConnectionState.Closed)
                 {
                     connection.Open();
                 }
 
-                var command = new SqlCommand($"SELECT Id FROM [dbo].[BusinessProcesses] WHERE TransactionId = '{transaction.Value}'", connection);
-                var id = command.ExecuteScalar();
-                _businessProcessId = new BusinessProcessId(Guid.Parse(id.ToString()));
+                using var command = new SqlCommand($"SELECT Id FROM [dbo].[BusinessProcesses] WHERE TransactionId = @transaction", connection);
+                command.Parameters.Add("@transaction", SqlDbType.NVarChar).Value = transaction.Value;
+                var id = (Guid)command.ExecuteScalar();
+                _businessProcessId = BusinessProcessId.Create(id);
             }
 
             return _businessProcessId;
@@ -377,6 +410,8 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
 
         protected async Task AssertOutboxMessageAsync<TMessage>(Func<TMessage, bool> funcAssert)
         {
+            if (funcAssert == null) throw new ArgumentNullException(nameof(funcAssert));
+
             var publishedMessage = await GetLastMessageFromOutboxAsync<TMessage>().ConfigureAwait(false);
             var assertion = funcAssert.Invoke(publishedMessage);
 
@@ -402,7 +437,8 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
                                    $"DELETE FROM [dbo].[OutboxMessages] " +
                                    $"DELETE FROM [dbo].[QueuedInternalCommands]";
 
-            new SqlCommand(cleanupStatement, GetSqlDbConnection()).ExecuteNonQuery();
+            using var sqlCommand = new SqlCommand(cleanupStatement, GetSqlDbConnection());
+            sqlCommand.ExecuteNonQuery();
         }
     }
 }

--- a/source/Energinet.DataHub.MarketRoles.IntegrationTests/Energinet.DataHub.MarketRoles.IntegrationTests.csproj
+++ b/source/Energinet.DataHub.MarketRoles.IntegrationTests/Energinet.DataHub.MarketRoles.IntegrationTests.csproj
@@ -19,7 +19,6 @@ limitations under the License.
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>
-    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Energinet.DataHub.MarketRoles.IntegrationTests/Transport/TestImplementations/InProcessChannel.cs
+++ b/source/Energinet.DataHub.MarketRoles.IntegrationTests/Transport/TestImplementations/InProcessChannel.cs
@@ -21,7 +21,7 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Transport.TestImplement
 {
     public class InProcessChannel : Channel
     {
-        private byte[] _writtenBytes;
+        private byte[]? _writtenBytes;
 
         public byte[] GetWrittenBytes() => _writtenBytes ?? throw new InvalidOperationException("Write bytes before getting them.");
 

--- a/source/Energinet.DataHub.MarketRoles.IntegrationTests/Transport/TestImplementations/TransportTestInboundMapper.cs
+++ b/source/Energinet.DataHub.MarketRoles.IntegrationTests/Transport/TestImplementations/TransportTestInboundMapper.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Energinet.DataHub.MarketRoles.Application.Common.Transport;
 using Energinet.DataHub.MarketRoles.Contracts;
 using Energinet.DataHub.MarketRoles.Infrastructure.Transport.Protobuf;
@@ -22,6 +23,8 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Transport.TestImplement
     {
         protected override IInboundMessage Convert(TestMessage obj)
         {
+            if (obj == null) throw new ArgumentNullException(nameof(obj));
+
             return new TransportTestRecord(obj.TestProperty);
         }
     }

--- a/source/Energinet.DataHub.MarketRoles.IntegrationTests/Transport/TestImplementations/TransportTestOutboundMapper.cs
+++ b/source/Energinet.DataHub.MarketRoles.IntegrationTests/Transport/TestImplementations/TransportTestOutboundMapper.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Energinet.DataHub.MarketRoles.Contracts;
 using Energinet.DataHub.MarketRoles.Infrastructure.Transport.Protobuf;
 using Google.Protobuf;
@@ -22,6 +23,8 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Transport.TestImplement
     {
         protected override IMessage Convert(TransportTestRecord obj)
         {
+            if (obj == null) throw new ArgumentNullException(nameof(obj));
+
             return new TestEnvelope()
             {
                 TestMessage = new TestMessage

--- a/source/Energinet.DataHub.MarketRoles.IntegrationTests/Transport/TransportTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.IntegrationTests/Transport/TransportTests.cs
@@ -31,7 +31,7 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Transport
         [Fact]
         public async Task Send_and_receive_must_result_in_same_transmitted_values()
         {
-            var container = new Container();
+            await using var container = new Container();
             container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
 
             // Send Registrations

--- a/source/Energinet.DataHub.MarketRoles.Tests/Application/ChangeOfSupplier/Process/ChangeOfSupplierProcessManagerTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.Tests/Application/ChangeOfSupplier/Process/ChangeOfSupplierProcessManagerTests.cs
@@ -159,7 +159,7 @@ namespace Energinet.DataHub.MarketRoles.Tests.Application.ChangeOfSupplier.Proce
             Assert.True(processManager.IsCompleted());
         }
 
-        private ChangeOfSupplierProcessManager Create()
+        private static ChangeOfSupplierProcessManager Create()
         {
             return new ChangeOfSupplierProcessManager();
         }

--- a/source/Energinet.DataHub.MarketRoles.Tests/Application/ChangeOfSupplier/Validation/RequestChangeOfSupplierRuleSetTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.Tests/Application/ChangeOfSupplier/Validation/RequestChangeOfSupplierRuleSetTests.cs
@@ -118,7 +118,7 @@ namespace Energinet.DataHub.MarketRoles.Tests.Application.ChangeOfSupplier.Valid
             Assert.DoesNotContain(errors, error => error is StartOfSupplyMustBeValidRuleError);
         }
 
-        private RequestChangeOfSupplier CreateRequest(string transaction = "", string glnNumber = "", string gsrnNumber = "")
+        private static RequestChangeOfSupplier CreateRequest(string transaction = "", string glnNumber = "", string gsrnNumber = "")
         {
             return new RequestChangeOfSupplier(
                 transaction,
@@ -129,7 +129,7 @@ namespace Energinet.DataHub.MarketRoles.Tests.Application.ChangeOfSupplier.Valid
                 SystemClock.Instance.GetCurrentInstant().ToString());
         }
 
-        private RequestChangeOfSupplier CreateRequest(string transaction = "", string glnNumber = "", string gsrnNumber = "", string startDate = "")
+        private static RequestChangeOfSupplier CreateRequest(string transaction = "", string glnNumber = "", string gsrnNumber = "", string startDate = "")
         {
             return new RequestChangeOfSupplier(
                 transaction,
@@ -140,12 +140,12 @@ namespace Energinet.DataHub.MarketRoles.Tests.Application.ChangeOfSupplier.Valid
                 startDate);
         }
 
-        private List<ValidationError> GetValidationErrors(RequestChangeOfSupplier request)
+        private static List<ValidationError> GetValidationErrors(RequestChangeOfSupplier request)
         {
             var ruleSet = new RequestChangeOfSupplierRuleSet();
             var validationResult = ruleSet.Validate(request);
             return validationResult.Errors
-                .Select(error => error.CustomState as ValidationError)
+                .Select(error => (ValidationError)error.CustomState)
                 .ToList();
         }
     }

--- a/source/Energinet.DataHub.MarketRoles.Tests/Application/MoveIn/Validation/RequestMoveInRuleSetTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.Tests/Application/MoveIn/Validation/RequestMoveInRuleSetTests.cs
@@ -108,7 +108,7 @@ namespace Energinet.DataHub.MarketRoles.Tests.Application.MoveIn.Validation
             Assert.Contains(errors, error => error is VATNumberMustBeValidRuleError);
         }
 
-        private RequestMoveIn CreateRequest(string socialSecurityNumber, string vatNumber)
+        private static RequestMoveIn CreateRequest(string socialSecurityNumber, string vatNumber)
         {
             return new(
                 SampleData.Transaction,
@@ -120,12 +120,12 @@ namespace Energinet.DataHub.MarketRoles.Tests.Application.MoveIn.Validation
                 SampleData.StartDate);
         }
 
-        private List<ValidationError> GetValidationErrors(RequestMoveIn request)
+        private static List<ValidationError> GetValidationErrors(RequestMoveIn request)
         {
             var ruleSet = new RequestMoveInRuleSet();
             var validationResult = ruleSet.Validate(request);
             return validationResult.Errors
-                .Select(error => error.CustomState as ValidationError)
+                .Select(error => (ValidationError)error.CustomState)
                 .ToList();
         }
     }

--- a/source/Energinet.DataHub.MarketRoles.Tests/Domain/Consumers/ConsumerTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.Tests/Domain/Consumers/ConsumerTests.cs
@@ -49,20 +49,20 @@ namespace Energinet.DataHub.MarketRoles.Tests.Domain.Consumers
         {
             var consumer = new Consumer(CreateConsumerId(), CreateCprNumber(), CreateName());
 
-            var @event = consumer.DomainEvents.FirstOrDefault() as ConsumerCreated;
+            ConsumerCreated? @event = consumer.DomainEvents.FirstOrDefault() as ConsumerCreated;
 
             Assert.NotNull(@event);
-            Assert.Equal(consumer.ConsumerId.Value, @event.ConsumerId);
+            Assert.Equal(consumer.ConsumerId.Value, @event!.ConsumerId);
             Assert.Equal(consumer.CprNumber?.Value, @event.CprNumber);
             Assert.Equal(consumer.CvrNumber?.Value, @event.CvrNumber);
             Assert.Equal(SampleData.ConsumerName, @event.FullName);
         }
 
-        private ConsumerName CreateName() => ConsumerName.Create(SampleData.ConsumerName);
+        private static ConsumerName CreateName() => ConsumerName.Create(SampleData.ConsumerName);
 
-        private CprNumber CreateCprNumber() => CprNumber.Create(SampleData.ConsumerSocialSecurityNumber);
+        private static CprNumber CreateCprNumber() => CprNumber.Create(SampleData.ConsumerSocialSecurityNumber);
 
-        private ConsumerId CreateConsumerId()
+        private static ConsumerId CreateConsumerId()
         {
             return new ConsumerId(Guid.NewGuid());
         }

--- a/source/Energinet.DataHub.MarketRoles.Tests/Domain/MeteringPoints/ChangeOfSupplier/CancellationTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.Tests/Domain/MeteringPoints/ChangeOfSupplier/CancellationTests.cs
@@ -57,28 +57,28 @@ namespace Energinet.DataHub.MarketRoles.Tests.Domain.MeteringPoints.ChangeOfSupp
             Assert.Throws<BusinessProcessException>(() => meteringPoint.CancelChangeOfSupplier(transaction));
         }
 
-        private (AccountingPoint, Transaction) CreateWithActiveMoveIn()
+        private static Transaction CreateTransaction()
+        {
+            return new Transaction(Guid.NewGuid().ToString());
+        }
+
+        private static EnergySupplierId CreateEnergySupplierId()
+        {
+            return new EnergySupplierId(Guid.NewGuid());
+        }
+
+        private static ConsumerId CreateConsumerId()
+        {
+            return new ConsumerId(Guid.NewGuid());
+        }
+
+        private (AccountingPoint AccountingPoint, Transaction Transaction) CreateWithActiveMoveIn()
         {
             var accountingPoint = new AccountingPoint(GsrnNumber.Create("571234567891234568"), MeteringPointType.Consumption);
             var transaction = CreateTransaction();
             accountingPoint.AcceptConsumerMoveIn(CreateConsumerId(), CreateEnergySupplierId(), _systemDateTimeProvider.Now().Minus(Duration.FromDays(365)), transaction);
             accountingPoint.EffectuateConsumerMoveIn(transaction, _systemDateTimeProvider);
             return (accountingPoint, transaction);
-        }
-
-        private Transaction CreateTransaction()
-        {
-            return new Transaction(Guid.NewGuid().ToString());
-        }
-
-        private EnergySupplierId CreateEnergySupplierId()
-        {
-            return new EnergySupplierId(Guid.NewGuid());
-        }
-
-        private ConsumerId CreateConsumerId()
-        {
-            return new ConsumerId(Guid.NewGuid());
         }
     }
 }

--- a/source/Energinet.DataHub.MarketRoles.Tests/Domain/MeteringPoints/ChangeOfSupplier/EffectuateTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.Tests/Domain/MeteringPoints/ChangeOfSupplier/EffectuateTests.cs
@@ -62,6 +62,21 @@ namespace Energinet.DataHub.MarketRoles.Tests.Domain.MeteringPoints.ChangeOfSupp
             Assert.NotNull(@event);
         }
 
+        private static Transaction CreateTransaction()
+        {
+            return new Transaction(Guid.NewGuid().ToString());
+        }
+
+        private static EnergySupplierId CreateEnergySupplierId()
+        {
+            return new EnergySupplierId(Guid.NewGuid());
+        }
+
+        private static ConsumerId CreateConsumerId()
+        {
+            return new ConsumerId(Guid.NewGuid());
+        }
+
         private AccountingPoint CreateTestObject()
         {
             var accountingPoint = new AccountingPoint(GsrnNumber.Create("571234567891234568"), MeteringPointType.Consumption);
@@ -69,21 +84,6 @@ namespace Energinet.DataHub.MarketRoles.Tests.Domain.MeteringPoints.ChangeOfSupp
             accountingPoint.AcceptConsumerMoveIn(CreateConsumerId(), CreateEnergySupplierId(), _systemDateTimeProvider.Now().Minus(Duration.FromDays(365)), transaction);
             accountingPoint.EffectuateConsumerMoveIn(transaction, _systemDateTimeProvider);
             return accountingPoint;
-        }
-
-        private Transaction CreateTransaction()
-        {
-            return new Transaction(Guid.NewGuid().ToString());
-        }
-
-        private EnergySupplierId CreateEnergySupplierId()
-        {
-            return new EnergySupplierId(Guid.NewGuid());
-        }
-
-        private ConsumerId CreateConsumerId()
-        {
-            return new ConsumerId(Guid.NewGuid());
         }
     }
 }

--- a/source/Energinet.DataHub.MarketRoles.Tests/Domain/MeteringPoints/MoveIn/AcceptTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.Tests/Domain/MeteringPoints/MoveIn/AcceptTests.cs
@@ -58,7 +58,7 @@ namespace Energinet.DataHub.MarketRoles.Tests.Domain.MeteringPoints.MoveIn
             Assert.Contains(result.Errors, error => error is MoveInRegisteredOnSameDateIsNotAllowedRuleError);
         }
 
-        private AccountingPoint Create()
+        private static AccountingPoint Create()
         {
             var gsrnNumber = GsrnNumber.Create(SampleData.GsrnNumber);
             return new AccountingPoint(gsrnNumber, MeteringPointType.Consumption);

--- a/source/Energinet.DataHub.MarketRoles.Tests/Domain/MeteringPoints/MoveIn/EffectuateTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.Tests/Domain/MeteringPoints/MoveIn/EffectuateTests.cs
@@ -67,7 +67,7 @@ namespace Energinet.DataHub.MarketRoles.Tests.Domain.MeteringPoints.MoveIn
             Assert.Contains(accountingPoint.DomainEvents, @event => @event is ConsumerMovedIn);
         }
 
-        private (AccountingPoint, ConsumerId, EnergySupplierId, Transaction) SetupScenario()
+        private static (AccountingPoint AccountingPoint, ConsumerId ConsumerId, EnergySupplierId EnergySupplierId, Transaction Transaction) SetupScenario()
         {
             return (
                 new AccountingPoint(GsrnNumber.Create(SampleData.GsrnNumber), MeteringPointType.Consumption),

--- a/source/Energinet.DataHub.MarketRoles.Tests/EDI/XmlConverterTests.cs
+++ b/source/Energinet.DataHub.MarketRoles.Tests/EDI/XmlConverterTests.cs
@@ -51,7 +51,7 @@ namespace Energinet.DataHub.MarketRoles.Tests.EDI
         {
             var stream = GetResourceStream("ChangeOfSupplierCimXml.xml");
 
-            var commandsRaw = await _xmlDeserializer.DeserializeAsync(stream);
+            var commandsRaw = await _xmlDeserializer.DeserializeAsync(stream).ConfigureAwait(false);
             var commands = commandsRaw.Cast<RequestChangeOfSupplier>();
 
             var command = commands.First();
@@ -68,7 +68,7 @@ namespace Energinet.DataHub.MarketRoles.Tests.EDI
         {
             var stream = GetResourceStream("MoveInCimXml.xml");
 
-            var commandsRaw = await _xmlDeserializer.DeserializeAsync(stream);
+            var commandsRaw = await _xmlDeserializer.DeserializeAsync(stream).ConfigureAwait(false);
             var commands = commandsRaw.Cast<RequestMoveIn>();
 
             var command = commands.First();
@@ -87,15 +87,12 @@ namespace Energinet.DataHub.MarketRoles.Tests.EDI
             var assembly = Assembly.GetExecutingAssembly();
             var resourceNames = new List<string>(assembly.GetManifestResourceNames());
 
-            resourcePath = resourcePath.Replace(@"/", ".");
-            resourcePath = resourceNames.FirstOrDefault(r => r.Contains(resourcePath));
+            var resourceName = resourcePath.Replace(@"/", ".", StringComparison.Ordinal);
+            var resource = resourceNames.FirstOrDefault(r => r.Contains(resourceName, StringComparison.Ordinal))
+                           ?? throw new FileNotFoundException("Resource not found");
 
-            if (resourcePath == null)
-            {
-                throw new FileNotFoundException("Resource not found");
-            }
-
-            return assembly.GetManifestResourceStream(resourcePath);
+            return assembly.GetManifestResourceStream(resource)
+                   ?? throw new InvalidOperationException($"Couldn't get requested resource: {resourcePath}");
         }
 
         private static XmlMappingConfigurationBase XmlMapperFactory(string processType, string type)

--- a/source/Energinet.DataHub.MarketRoles.Tests/Energinet.DataHub.MarketRoles.Tests.csproj
+++ b/source/Energinet.DataHub.MarketRoles.Tests/Energinet.DataHub.MarketRoles.Tests.csproj
@@ -15,39 +15,38 @@ limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentValidation" Version="10.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.categories" Version="2.0.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="FluentValidation" Version="10.3.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.categories" Version="2.0.5" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.3">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Energinet.DataHub.MarketRoles.Application\Energinet.DataHub.MarketRoles.Application.csproj" />
+    <ProjectReference Include="..\Energinet.DataHub.MarketRoles.Domain\Energinet.DataHub.MarketRoles.Domain.csproj" />
+    <ProjectReference Include="..\Energinet.DataHub.MarketRoles.EntryPoints.Ingestion\Energinet.DataHub.MarketRoles.EntryPoints.Ingestion.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Energinet.DataHub.MarketRoles.Application\Energinet.DataHub.MarketRoles.Application.csproj" />
-      <ProjectReference Include="..\Energinet.DataHub.MarketRoles.Domain\Energinet.DataHub.MarketRoles.Domain.csproj" />
-      <ProjectReference Include="..\Energinet.DataHub.MarketRoles.EntryPoints.Ingestion\Energinet.DataHub.MarketRoles.EntryPoints.Ingestion.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <None Remove="EDI\ChangeOfSupplierCimXml.xml" />
-      <EmbeddedResource Include="EDI\ChangeOfSupplierCimXml.xml" />
-      <None Remove="EDI\MoveInCimXml.xml" />
-      <EmbeddedResource Include="EDI\MoveInCimXml.xml" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Remove="EDI\ChangeOfSupplierCimXml.xml" />
+    <EmbeddedResource Include="EDI\ChangeOfSupplierCimXml.xml" />
+    <None Remove="EDI\MoveInCimXml.xml" />
+    <EmbeddedResource Include="EDI\MoveInCimXml.xml" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR moves (inconsistent) analyzer settings from all csproj's to the common props file (Directory.Build.props).
It also fixes the warnings that now present themselves as errors.