### PR TITLE
Added ExternalAnnotations

### DIFF
--- a/source/ExternalAnnotations/FluentValidation.xml
+++ b/source/ExternalAnnotations/FluentValidation.xml
@@ -1,0 +1,19 @@
+<!--
+Copyright 2020 Energinet DataHub A/S
+Licensed under the Apache License, Version 2.0 (the "License2");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<assembly name="FluentValidation">
+    <member name="T:FluentValidation.AbstractValidator`1">
+        <attribute ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)" >
+            <argument>5</argument>
+        </attribute>
+    </member>
+</assembly>

--- a/source/ExternalAnnotations/MediatR.xml
+++ b/source/ExternalAnnotations/MediatR.xml
@@ -1,0 +1,19 @@
+<!--
+Copyright 2020 Energinet DataHub A/S
+Licensed under the Apache License, Version 2.0 (the "License2");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<assembly name="MediatR">
+    <member name="T:MediatR.IRequestHandler`2">
+        <attribute ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)" >
+            <argument>5</argument>
+        </attribute>
+    </member>
+</assembly>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description

Added ExternalAnnotations like in MeteringPoint repo. Used to make it obvious that instances registered/invoked by Open Generics and Reflection are actually in use.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
