### PR TITLE
fix: using local db shouldn't use container

### DIFF
--- a/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/TestHost.cs
+++ b/source/Energinet.DataHub.MarketRoles.IntegrationTests/Application/TestHost.cs
@@ -88,7 +88,7 @@ namespace Energinet.DataHub.MarketRoles.IntegrationTests.Application
         {
             if (databaseFixture == null) throw new ArgumentNullException(nameof(databaseFixture));
 
-            _connectionString = databaseFixture.GetConnectionString.Value;
+            _connectionString = databaseFixture.GetConnectionString();
 
             _container = new Container();
             var serviceCollection = new ServiceCollection();


### PR DESCRIPTION
This PR fixes a bug where a container will be used regardless of whether or not you're running with a local database.

Use `IntegrationTests_ConnectionString` as local database name.

fixes #700