### PR TITLE
Changed integration queue listener to Market Roles instead of Metering Point

### DIFF
--- a/build/infrastructure/main/kv-sharedresources.tf
+++ b/build/infrastructure/main/kv-sharedresources.tf
@@ -37,6 +37,6 @@ data "azurerm_key_vault_secret" "SHARED_RESOURCES_DB_URL" {
 }
 
 data "azurerm_key_vault_secret" "SHARED_RESOURCES_EVENT_FORWARDED_QUEUE" {
-  name         = "METERING-POINT-FORWARDED-QUEUE-NAME"
+  name         = "MARKET-ROLES-FORWARDED-QUEUE-NAME"
   key_vault_id = data.azurerm_key_vault.kv_sharedresources.id
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description
See title

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
