### PR TITLE
Moved correlation id to the header instead of body

### DIFF
--- a/source/Energinet.DataHub.MarketRoles.EntryPoints.Ingestion/CommandApi.cs
+++ b/source/Energinet.DataHub.MarketRoles.EntryPoints.Ingestion/CommandApi.cs
@@ -64,20 +64,25 @@ namespace Energinet.DataHub.MarketRoles.EntryPoints.Ingestion
             catch (Exception exception)
             {
                 _logger.LogError(exception, "Unable to deserialize request");
-                return request.CreateResponse(HttpStatusCode.BadRequest);
+                return CreateResponse(request, HttpStatusCode.BadRequest);
             }
 
-            var response = request.CreateResponse(HttpStatusCode.OK);
+            var response = CreateResponse(request, HttpStatusCode.OK);
 
             response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
-
-            await response.WriteStringAsync("Correlation id: " + _correlationContext.Id)
-                .ConfigureAwait(false);
 
             foreach (var command in commands)
             {
                 await _messageDispatcher.DispatchAsync((IOutboundMessage)command).ConfigureAwait(false);
             }
+
+            return response;
+        }
+
+        private HttpResponseData CreateResponse(HttpRequestData request, HttpStatusCode statusCode)
+        {
+            var response = request.CreateResponse(statusCode);
+            response.Headers.Add("CorrelationId", _correlationContext.Id);
 
             return response;
         }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description

Moved correlation id to the header as per our documentation.
Also made sure that we include it on all requests and not just the successful ones.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* https://github.com/Energinet-DataHub/green-energy-hub/issues/270
