### PR TITLE
Add B2B response factory

### DIFF
--- a/source/B2B.Transactions.CimMessageAdapter.Tests/ResponseFactoryTests.cs
+++ b/source/B2B.Transactions.CimMessageAdapter.Tests/ResponseFactoryTests.cs
@@ -31,11 +31,14 @@ namespace MarketRoles.B2B.CimMessageAdapter.IntegrationTests
 
             var response = ResponseFactory.From(result);
 
+            AssertHasValue(response, "Code", duplicateMessageIdError.Code);
+            AssertHasValue(response, "Message", duplicateMessageIdError.Message);
+        }
+
+        private static void AssertHasValue(Response response, string elementName, string expectedValue)
+        {
             var document = XDocument.Parse(response.MessageBody);
-            var code = document?.Element("Error")?.Element("Code")?.Value;
-            var message = document?.Element("Error")?.Element("Message")?.Value;
-            Assert.Equal(duplicateMessageIdError.Code, code);
-            Assert.Equal(duplicateMessageIdError.Message, message);
+            Assert.Equal(expectedValue, document?.Element("Error")?.Element(elementName)?.Value);
         }
     }
 

--- a/source/B2B.Transactions.CimMessageAdapter.Tests/ResponseFactoryTests.cs
+++ b/source/B2B.Transactions.CimMessageAdapter.Tests/ResponseFactoryTests.cs
@@ -87,7 +87,7 @@ namespace MarketRoles.B2B.CimMessageAdapter.IntegrationTests
     {
         public Response From(Result result)
         {
-            return result.Success ? new Response() : new Response(true, CreateMessageBodyFrom(result));
+            return result.Success ? new Response() : new Response(CreateMessageBodyFrom(result));
         }
 
         private string CreateMessageBodyFrom(Result result)
@@ -120,9 +120,9 @@ namespace MarketRoles.B2B.CimMessageAdapter.IntegrationTests
 
     public class Response
     {
-        internal Response(bool isErrorResponse, string messageBody)
+        internal Response(string messageBody)
         {
-            IsErrorResponse = isErrorResponse;
+            IsErrorResponse = true;
             MessageBody = messageBody;
         }
 

--- a/source/B2B.Transactions.CimMessageAdapter.Tests/ResponseFactoryTests.cs
+++ b/source/B2B.Transactions.CimMessageAdapter.Tests/ResponseFactoryTests.cs
@@ -31,6 +31,7 @@ namespace MarketRoles.B2B.CimMessageAdapter.IntegrationTests
 
             var response = ResponseFactory.From(result);
 
+            Assert.True(response.IsErrorResponse);
             AssertHasValue(response, "Code", duplicateMessageIdError.Code);
             AssertHasValue(response, "Message", duplicateMessageIdError.Message);
         }
@@ -44,6 +45,7 @@ namespace MarketRoles.B2B.CimMessageAdapter.IntegrationTests
 
             var response = ResponseFactory.From(result);
 
+            Assert.True(response.IsErrorResponse);
             AssertHasValue(response, "Code", "BadRequest");
             AssertHasValue(response, "Message", "Multiple errors in message");
             AssertContainsError(response, duplicateMessageIdError);
@@ -82,7 +84,7 @@ namespace MarketRoles.B2B.CimMessageAdapter.IntegrationTests
                     detailsBuilder.AppendLine("</Error>");
                 }
 
-                return new Response($"<Error>" +
+                return new Response(true, $"<Error>" +
                                     "<Code>BadRequest</Code>" +
                                     "<Message>Multiple errors in message</Message>" +
                                     $"<Details>{detailsBuilder}</Details>" +
@@ -93,28 +95,28 @@ namespace MarketRoles.B2B.CimMessageAdapter.IntegrationTests
                                     "</InnerError>" +
                                     "</Error>");
             }
-            else
-            {
-                return new Response($"<Error>" +
-                                    $"<Code>{result.Errors.First().Code}</Code>" +
-                                    $"<Message>{result.Errors.First().Message}</Message>" +
-                                    "<InnerError>" +
-                                    "<Code>MessageIdPreviousUsed</Code>" +
-                                    "<Message-Id>gs8u033bqn</Message-Id>" +
-                                    "<Used-on>2018-05-16T15:32:12Z</Used-on>" +
-                                    "</InnerError>" +
-                                    "</Error>");
-            }
+
+            return new Response(true, $"<Error>" +
+                                      $"<Code>{result.Errors.First().Code}</Code>" +
+                                      $"<Message>{result.Errors.First().Message}</Message>" +
+                                      "<InnerError>" +
+                                      "<Code>MessageIdPreviousUsed</Code>" +
+                                      "<Message-Id>gs8u033bqn</Message-Id>" +
+                                      "<Used-on>2018-05-16T15:32:12Z</Used-on>" +
+                                      "</InnerError>" +
+                                      "</Error>");
         }
     }
 
     public class Response
     {
-        public Response(string messageBody)
+        internal Response(bool isErrorResponse, string messageBody)
         {
+            IsErrorResponse = isErrorResponse;
             MessageBody = messageBody;
         }
 
         public string MessageBody { get; }
+        public bool IsErrorResponse { get; }
     }
 }

--- a/source/B2B.Transactions.CimMessageAdapter.Tests/ResponseFactoryTests.cs
+++ b/source/B2B.Transactions.CimMessageAdapter.Tests/ResponseFactoryTests.cs
@@ -27,6 +27,17 @@ namespace MarketRoles.B2B.CimMessageAdapter.IntegrationTests
         private readonly ResponseFactory _responseFactory = new();
 
         [Fact]
+        public void Generate_empty_response_when_no_validation_errors_has_occurred()
+        {
+            var result = Result.Succeeded();
+
+            var response = _responseFactory.From(result);
+
+            Assert.False(response.IsErrorResponse);
+            Assert.Null(response.MessageBody);
+        }
+
+        [Fact]
         public void Generates_single_error_response()
         {
             var duplicateMessageIdError = new DuplicateMessageIdDetected("Duplicate message id");
@@ -76,7 +87,7 @@ namespace MarketRoles.B2B.CimMessageAdapter.IntegrationTests
     {
         public Response From(Result result)
         {
-            return new Response(true, CreateMessageBodyFrom(result));
+            return result.Success ? new Response() : new Response(true, CreateMessageBodyFrom(result));
         }
 
         private string CreateMessageBodyFrom(Result result)
@@ -113,6 +124,11 @@ namespace MarketRoles.B2B.CimMessageAdapter.IntegrationTests
         {
             IsErrorResponse = isErrorResponse;
             MessageBody = messageBody;
+        }
+
+        internal Response()
+        {
+            IsErrorResponse = false;
         }
 
         public string MessageBody { get; }

--- a/source/B2B.Transactions.CimMessageAdapter.Tests/ResponseFactoryTests.cs
+++ b/source/B2B.Transactions.CimMessageAdapter.Tests/ResponseFactoryTests.cs
@@ -1,0 +1,69 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using B2B.CimMessageAdapter;
+using B2B.CimMessageAdapter.Errors;
+using Xunit;
+
+namespace MarketRoles.B2B.CimMessageAdapter.IntegrationTests
+{
+    public class ResponseFactoryTests
+    {
+        [Fact]
+        public void Generates_single_error_response()
+        {
+            var duplicateMessageIdError = new DuplicateMessageIdDetected("Duplicate message id");
+            var result = Result.Failure(duplicateMessageIdError);
+
+            var response = ResponseFactory.From(result);
+
+            var document = XDocument.Parse(response.MessageBody);
+            var code = document?.Element("Error")?.Element("Code")?.Value;
+            var message = document?.Element("Error")?.Element("Message")?.Value;
+            Assert.Equal(duplicateMessageIdError.Code, code);
+            Assert.Equal(duplicateMessageIdError.Message, message);
+        }
+    }
+
+    #pragma warning disable
+    public class ResponseFactory
+    {
+        public static Response From(Result result)
+        {
+            var messageBody = $"<Error>" +
+                                    $"<Code>{ result.Errors.First().Code }</Code>" +
+                                    $"<Message>{result.Errors.First().Message}</Message>" +
+                                    "<InnerError>" +
+                                        "<Code>MessageIdPreviousUsed</Code>" +
+                                        "<Message-Id>gs8u033bqn</Message-Id>" +
+                                        "<Used-on>2018-05-16T15:32:12Z</Used-on>" +
+                                    "</InnerError>" +
+                                "</Error>";
+            return new Response(messageBody);
+        }
+    }
+
+    public class Response
+    {
+        public Response(string messageBody)
+        {
+            MessageBody = messageBody;
+        }
+
+        public string MessageBody { get; }
+    }
+}

--- a/source/B2B.Transactions.CimMessageAdapter/Response/ResponseFactory.cs
+++ b/source/B2B.Transactions.CimMessageAdapter/Response/ResponseFactory.cs
@@ -1,0 +1,59 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Text;
+using System.Xml;
+
+namespace B2B.CimMessageAdapter.Response
+{
+    public static class ResponseFactory
+    {
+        public static ResponseMessage From(Result result)
+        {
+            if (result == null) throw new ArgumentNullException(nameof(result));
+            return result.Success ? new ResponseMessage() : new ResponseMessage(CreateMessageBodyFrom(result));
+        }
+
+        private static string CreateMessageBodyFrom(Result result)
+        {
+            var messageBody = new StringBuilder();
+            var settings = new XmlWriterSettings() { OmitXmlDeclaration = true, };
+
+            using var writer = XmlWriter.Create(messageBody, settings);
+            writer.WriteStartElement("Error");
+            writer.WriteElementString("Code", result.Errors.Count == 1 ? result.Errors.First().Code : "BadRequest");
+            writer.WriteElementString("Message", result.Errors.Count == 1 ? result.Errors.First().Message : "Multiple errors in message");
+            if (result.Errors.Count > 1)
+            {
+                writer.WriteStartElement("Details");
+                foreach (var validationError in result.Errors)
+                {
+                    writer.WriteStartElement("Error");
+                    writer.WriteElementString("Code", validationError.Code);
+                    writer.WriteElementString("Message", validationError.Message);
+                    writer.WriteEndElement();
+                }
+
+                writer.WriteEndElement();
+            }
+
+            writer.WriteEndElement();
+            writer.Close();
+
+            return messageBody.ToString();
+        }
+    }
+}

--- a/source/B2B.Transactions.CimMessageAdapter/Response/ResponseMessage.cs
+++ b/source/B2B.Transactions.CimMessageAdapter/Response/ResponseMessage.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace B2B.CimMessageAdapter.Response
+{
+    public class ResponseMessage
+    {
+        internal ResponseMessage(string messageBody)
+        {
+            IsErrorResponse = true;
+            MessageBody = messageBody;
+        }
+
+        internal ResponseMessage()
+        {
+            IsErrorResponse = false;
+        }
+
+        public string MessageBody { get; } = string.Empty;
+
+        public bool IsErrorResponse { get; }
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description
This PR adds `ResponseFactory` which is responsible for generating a XML serialize B2B response message based on the result from `MessageReceiver`

TODO: Cleanup assert methods in test
<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
