### PR TITLE
Accessing service on ICorrelationContext instead of CorrelationContext

### DIFF
--- a/source/B2B.Transactions.Infrastructure/Configuration/Correlation/CorrelationIdMiddleware.cs
+++ b/source/B2B.Transactions.Infrastructure/Configuration/Correlation/CorrelationIdMiddleware.cs
@@ -40,7 +40,7 @@ namespace B2B.Transactions.Infrastructure.Configuration.Correlation
             _logger.LogInformation("Parsed TraceContext: " + context.TraceContext.TraceParent ?? string.Empty);
             var traceContext = TraceContext.Parse(context.TraceContext.TraceParent);
 
-            var correlationContext = context.GetService<CorrelationContext>();
+            var correlationContext = context.GetService<ICorrelationContext>();
             correlationContext.SetId(traceContext.TraceId);
             correlationContext.SetParentId(traceContext.ParentId);
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

Changed GetService<CorrelationContext> to GetService<ICorrelationContext>