### PR TITLE
Changed database instance to Singleton instead of Scoped

### DIFF
--- a/source/Messaging.Infrastructure/Configuration/CompositionRoot.cs
+++ b/source/Messaging.Infrastructure/Configuration/CompositionRoot.cs
@@ -114,7 +114,7 @@ namespace Messaging.Infrastructure.Configuration
         public CompositionRoot AddDatabaseConnectionFactory(string connectionString)
         {
             if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
-            _services.AddScoped<IDbConnectionFactory>(_ => new SqlDbConnectionFactory(connectionString));
+            _services.AddSingleton<IDbConnectionFactory>(_ => new SqlDbConnectionFactory(connectionString));
             return this;
         }
 
@@ -160,7 +160,12 @@ namespace Messaging.Infrastructure.Configuration
             return this;
         }
 
-        public CompositionRoot AddMessageHubServices(string storageServiceConnectionString, string storageServiceContainerName, string queueConnectionString, string dataAvailableQueue, string domainReplyQueue)
+        public CompositionRoot AddMessageHubServices(
+            string storageServiceConnectionString,
+            string storageServiceContainerName,
+            string queueConnectionString,
+            string dataAvailableQueue,
+            string domainReplyQueue)
         {
             _services.AddSingleton<StorageConfig>(s => new StorageConfig(storageServiceContainerName));
             _services.AddSingleton<IRequestBundleParser, RequestBundleParser>();


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description

Some users experience an issue with some requests being denied with a 401 status code.
This is an attempt at removing the risk of exhausting ports due to the DB instance not being a singleton (Which is recommended)

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
