### PR TITLE
Fix schema validation error handling

### DIFF
--- a/source/Messaging.CimMessageAdapter/Messages/MessageParser.cs
+++ b/source/Messaging.CimMessageAdapter/Messages/MessageParser.cs
@@ -62,6 +62,11 @@ namespace Messaging.CimMessageAdapter.Messages
                         marketActivityRecords.Add(marketActivityRecord);
                     }
 
+                    if (_errors.Count > 0)
+                    {
+                        return MessageParserResult.Failure(_errors.ToArray());
+                    }
+
                     return MessageParserResult.Succeeded(messageHeader, marketActivityRecords);
                 }
                 catch (XmlException exception)

--- a/source/Messaging.IntegrationTests/CimMessageAdapter/MessageReceiverTests.cs
+++ b/source/Messaging.IntegrationTests/CimMessageAdapter/MessageReceiverTests.cs
@@ -148,6 +148,20 @@ namespace Messaging.IntegrationTests.CimMessageAdapter
         }
 
         [Fact]
+        public async Task Return_error_if_a_required_value_is_missing()
+        {
+            using var message = BusinessMessageBuilder
+                .RequestChangeOfSupplier()
+                .RemoveElementFromMarketActivityRecordValue("start_DateAndOrTime.dateTime")
+                .Message();
+
+            var result = await ReceiveRequestChangeOfSupplierMessage(message).ConfigureAwait(false);
+
+            Assert.False(result.Success);
+            AssertContainsError(result, "B2B-005");
+        }
+
+        [Fact]
         public async Task Message_must_conform_to_xml_schema()
         {
             await using var message = BusinessMessageBuilder

--- a/source/Messaging.IntegrationTests/CimMessageAdapter/MessageReceiverTests.cs
+++ b/source/Messaging.IntegrationTests/CimMessageAdapter/MessageReceiverTests.cs
@@ -134,7 +134,7 @@ namespace Messaging.IntegrationTests.CimMessageAdapter
         }
 
         [Fact]
-        public async Task Return_error_if_message_is_missing_a_required_element()
+        public async Task Return_error_if_a_required_element_is_missing()
         {
             using var message = BusinessMessageBuilder
                 .RequestChangeOfSupplier()

--- a/source/Messaging.IntegrationTests/CimMessageAdapter/MessageReceiverTests.cs
+++ b/source/Messaging.IntegrationTests/CimMessageAdapter/MessageReceiverTests.cs
@@ -134,6 +134,20 @@ namespace Messaging.IntegrationTests.CimMessageAdapter
         }
 
         [Fact]
+        public async Task Return_error_if_message_is_missing_a_required_element()
+        {
+            using var message = BusinessMessageBuilder
+                .RequestChangeOfSupplier()
+                .RemoveElementFromMarketActivityRecord("mRID")
+                .Message();
+
+            var result = await ReceiveRequestChangeOfSupplierMessage(message).ConfigureAwait(false);
+
+            Assert.False(result.Success);
+            AssertContainsError(result, "B2B-005");
+        }
+
+        [Fact]
         public async Task Message_must_conform_to_xml_schema()
         {
             await using var message = BusinessMessageBuilder

--- a/source/Messaging.IntegrationTests/CimMessageAdapter/Messages/BusinessMessageBuilder.cs
+++ b/source/Messaging.IntegrationTests/CimMessageAdapter/Messages/BusinessMessageBuilder.cs
@@ -69,6 +69,13 @@ namespace Messaging.IntegrationTests.CimMessageAdapter.Messages
             return this;
         }
 
+        public BusinessMessageBuilder RemoveElementFromMarketActivityRecord(string elementName)
+        {
+            var elementToRemove = _document.Root?.Element(_xmlNamespace + "MktActivityRecord")?.Element(_xmlNamespace + elementName);
+            elementToRemove?.Remove();
+            return this;
+        }
+
         private void SetRootChildElementValue(string elementName, string value)
         {
             _document.Root!

--- a/source/Messaging.IntegrationTests/CimMessageAdapter/Messages/BusinessMessageBuilder.cs
+++ b/source/Messaging.IntegrationTests/CimMessageAdapter/Messages/BusinessMessageBuilder.cs
@@ -76,10 +76,21 @@ namespace Messaging.IntegrationTests.CimMessageAdapter.Messages
             return this;
         }
 
+        public BusinessMessageBuilder RemoveElementFromMarketActivityRecordValue(string elementName)
+        {
+            GetMarketActivityRecordChildElement(elementName).Value = string.Empty;
+            return this;
+        }
+
         private void SetRootChildElementValue(string elementName, string value)
         {
             _document.Root!
                 .Element(_xmlNamespace + elementName)!.Value = value;
+        }
+
+        private XElement GetMarketActivityRecordChildElement(string elementName)
+        {
+            return _document.Root?.Element(_xmlNamespace + "MktActivityRecord")?.Element(_xmlNamespace + elementName)!;
         }
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description
This PR fixes a problem where schema errors in the `MktActivityRecord` element did not result in a B2B-validation error.
