### PR TITLE
Effectuate move in immediately when effective date is in the past

### DIFF
--- a/source/Processing.Application/MoveIn/MoveInRequestHandler.cs
+++ b/source/Processing.Application/MoveIn/MoveInRequestHandler.cs
@@ -78,7 +78,7 @@ namespace Processing.Application.MoveIn
 
             var consumer = await GetOrCreateConsumerAsync(request).ConfigureAwait(false);
 
-            _consumerMoveInProcess.StartProcess(accountingPoint, consumer, energySupplier, consumerMovesInOn, Transaction.Create(request.TransactionId));
+            _consumerMoveInProcess.StartProcess(accountingPoint, consumer, energySupplier, consumerMovesInOn, Transaction.Create(request.TransactionId), _systemDateTimeProvider.Now());
 
             return BusinessProcessResult.Ok(request.TransactionId);
         }

--- a/source/Processing.Application/MoveIn/Processing/EffectuateConsumerMoveInHandler.cs
+++ b/source/Processing.Application/MoveIn/Processing/EffectuateConsumerMoveInHandler.cs
@@ -37,7 +37,7 @@ namespace Processing.Application.MoveIn.Processing
         {
             if (request == null) throw new ArgumentNullException(nameof(request));
             var accountingPoint = await _accountingPointRepository.GetByIdAsync(AccountingPointId.Create(request.AccountingPointId)).ConfigureAwait(false);
-            accountingPoint?.EffectuateConsumerMoveIn(Transaction.Create(request.Transaction), _systemDateTimeProvider);
+            accountingPoint?.EffectuateConsumerMoveIn(Transaction.Create(request.Transaction), _systemDateTimeProvider.Now());
             return Unit.Value;
         }
     }

--- a/source/Processing.Domain/BusinessProcesses/MoveIn/ConsumerMoveIn.cs
+++ b/source/Processing.Domain/BusinessProcesses/MoveIn/ConsumerMoveIn.cs
@@ -52,6 +52,15 @@ namespace Processing.Domain.BusinessProcesses.MoveIn
             if (energySupplier == null) throw new ArgumentNullException(nameof(energySupplier));
             if (consumerMovesInOn == null) throw new ArgumentNullException(nameof(consumerMovesInOn));
             accountingPoint.AcceptConsumerMoveIn(consumer.ConsumerId, energySupplier.EnergySupplierId, consumerMovesInOn.DateInUtc, transaction);
+            if (EffectiveDateIsInThePast(consumerMovesInOn, today))
+            {
+                accountingPoint.EffectuateConsumerMoveIn(transaction, today);
+            }
+        }
+
+        private static bool EffectiveDateIsInThePast(EffectiveDate consumerMovesInOn, Instant today)
+        {
+            return consumerMovesInOn.DateInUtc < today;
         }
     }
 }

--- a/source/Processing.Domain/BusinessProcesses/MoveIn/ConsumerMoveIn.cs
+++ b/source/Processing.Domain/BusinessProcesses/MoveIn/ConsumerMoveIn.cs
@@ -45,7 +45,7 @@ namespace Processing.Domain.BusinessProcesses.MoveIn
             return accountingPoint.ConsumerMoveInAcceptable(consumerMovesInOn.DateInUtc);
         }
 
-        public void StartProcess(AccountingPoint accountingPoint, Consumer consumer, EnergySupplier energySupplier, EffectiveDate consumerMovesInOn, Transaction transaction)
+        public void StartProcess(AccountingPoint accountingPoint, Consumer consumer, EnergySupplier energySupplier, EffectiveDate consumerMovesInOn, Transaction transaction, Instant today)
         {
             if (accountingPoint == null) throw new ArgumentNullException(nameof(accountingPoint));
             if (consumer == null) throw new ArgumentNullException(nameof(consumer));

--- a/source/Processing.Domain/MeteringPoints/AccountingPoint.cs
+++ b/source/Processing.Domain/MeteringPoints/AccountingPoint.cs
@@ -176,12 +176,12 @@ namespace Processing.Domain.MeteringPoints
             AddDomainEvent(new ConsumerMoveInAccepted(Id.Value, GsrnNumber.Value, businessProcess.BusinessProcessId.Value, businessProcess.Transaction.Value, consumerId.Value, energySupplierId.Value, moveInDate));
         }
 
-        public void EffectuateConsumerMoveIn(Transaction transaction, ISystemDateTimeProvider systemDateTimeProvider)
+        public void EffectuateConsumerMoveIn(Transaction transaction, Instant today)
         {
             if (transaction == null) throw new ArgumentNullException(nameof(transaction));
             var businessProcess = GetBusinessProcess(transaction, BusinessProcessType.MoveIn);
 
-            businessProcess.Effectuate(systemDateTimeProvider);
+            businessProcess.Effectuate(today);
             var newSupplier = _supplierRegistrations.Find(supplier => supplier.BusinessProcessId.Equals(businessProcess.BusinessProcessId))!;
             newSupplier.StartOfSupply(businessProcess.EffectiveDate);
 

--- a/source/Processing.Domain/MeteringPoints/BusinessProcess.cs
+++ b/source/Processing.Domain/MeteringPoints/BusinessProcess.cs
@@ -39,10 +39,17 @@ namespace Processing.Domain.MeteringPoints
 
         public BusinessProcessStatus Status { get; private set; }
 
+        public void Effectuate(Instant today)
+        {
+            EnsureNotTooEarly(today);
+            EnsureStatus();
+            Status = BusinessProcessStatus.Completed;
+        }
+
         public void Effectuate(ISystemDateTimeProvider systemDateTimeProvider)
         {
             if (systemDateTimeProvider == null) throw new ArgumentNullException(nameof(systemDateTimeProvider));
-            EnsureNotTooEarly(systemDateTimeProvider);
+            EnsureNotTooEarly(systemDateTimeProvider.Now());
             EnsureStatus();
             Status = BusinessProcessStatus.Completed;
         }
@@ -53,9 +60,9 @@ namespace Processing.Domain.MeteringPoints
             Status = BusinessProcessStatus.Cancelled;
         }
 
-        private void EnsureNotTooEarly(ISystemDateTimeProvider systemDateTimeProvider)
+        private void EnsureNotTooEarly(Instant today)
         {
-            if (EffectiveDate.ToDateTimeUtc().Date > systemDateTimeProvider.Now().ToDateTimeUtc().Date)
+            if (EffectiveDate.ToDateTimeUtc().Date > today.ToDateTimeUtc().Date)
             {
                 throw new BusinessProcessException(
                     "Pending business processes cannot be effectuated ahead of effective date.");

--- a/source/Processing.IntegrationTests/Application/TestHost.cs
+++ b/source/Processing.IntegrationTests/Application/TestHost.cs
@@ -364,7 +364,7 @@ namespace Processing.IntegrationTests.Application
 
             var systemTimeProvider = GetService<ISystemDateTimeProvider>();
             accountingPoint.AcceptConsumerMoveIn(consumerId, energySupplierId, moveInDate, transaction);
-            accountingPoint.EffectuateConsumerMoveIn(transaction, systemTimeProvider);
+            accountingPoint.EffectuateConsumerMoveIn(transaction, systemTimeProvider.Now());
         }
 
         protected void RegisterChangeOfSupplier(AccountingPoint accountingPoint, EnergySupplierId energySupplierId, Transaction transaction)

--- a/source/Processing.Tests/Domain/BusinessProcesses/MoveIn/ConsumerMoveInTests.cs
+++ b/source/Processing.Tests/Domain/BusinessProcesses/MoveIn/ConsumerMoveInTests.cs
@@ -45,6 +45,14 @@ public class ConsumerMoveInTests : TestBase
     }
 
     [Fact]
+    public void Move_in_is_effectuated_if_effective_date_is_in_the_past()
+    {
+        _consumerMoveInProcess.StartProcess(_accountingPoint, _consumer, _energySupplier, AsOfYesterday(), _transaction);
+
+        Assert.Contains(_accountingPoint.DomainEvents, @event => @event is ConsumerMovedIn);
+    }
+
+    [Fact]
     public void Throw_if_any_business_rules_are_broken()
     {
         _consumerMoveInProcess.StartProcess(_accountingPoint, _consumer, _energySupplier, AsOfToday(), _transaction);
@@ -110,5 +118,10 @@ public class ConsumerMoveInTests : TestBase
     private EffectiveDate AsOfToday()
     {
         return EffectiveDateFactory.WithTimeOfDay(SystemDateTimeProvider.Now().ToDateTimeUtc(), 22, 0, 0);
+    }
+
+    private EffectiveDate AsOfYesterday()
+    {
+        return EffectiveDateFactory.WithTimeOfDay(SystemDateTimeProvider.Now().Minus(Duration.FromDays(-1)).ToDateTimeUtc(), 22, 0, 0);
     }
 }

--- a/source/Processing.Tests/Domain/BusinessProcesses/MoveIn/ConsumerMoveInTests.cs
+++ b/source/Processing.Tests/Domain/BusinessProcesses/MoveIn/ConsumerMoveInTests.cs
@@ -122,6 +122,6 @@ public class ConsumerMoveInTests : TestBase
 
     private EffectiveDate AsOfYesterday()
     {
-        return EffectiveDateFactory.WithTimeOfDay(SystemDateTimeProvider.Now().Minus(Duration.FromDays(-1)).ToDateTimeUtc(), 22, 0, 0);
+        return EffectiveDateFactory.WithTimeOfDay(SystemDateTimeProvider.Now().Minus(Duration.FromDays(1)).ToDateTimeUtc(), 22, 0, 0);
     }
 }

--- a/source/Processing.Tests/Domain/BusinessProcesses/MoveIn/ConsumerMoveInTests.cs
+++ b/source/Processing.Tests/Domain/BusinessProcesses/MoveIn/ConsumerMoveInTests.cs
@@ -85,7 +85,7 @@ public class ConsumerMoveInTests : TestBase
     {
         var moveInDate = AsOfToday();
         _consumerMoveInProcess.StartProcess(_accountingPoint, _consumer, _energySupplier, moveInDate, _transaction);
-        _accountingPoint.EffectuateConsumerMoveIn(_transaction, SystemDateTimeProvider);
+        _accountingPoint.EffectuateConsumerMoveIn(_transaction, SystemDateTimeProvider.Now());
 
         var result = CanStartProcess(moveInDate);
 

--- a/source/Processing.Tests/Domain/BusinessProcesses/MoveIn/ConsumerMoveInTests.cs
+++ b/source/Processing.Tests/Domain/BusinessProcesses/MoveIn/ConsumerMoveInTests.cs
@@ -47,7 +47,7 @@ public class ConsumerMoveInTests : TestBase
     [Fact]
     public void Move_in_is_effectuated_if_effective_date_is_in_the_past()
     {
-        _consumerMoveInProcess.StartProcess(_accountingPoint, _consumer, _energySupplier, AsOfYesterday(), _transaction);
+        _consumerMoveInProcess.StartProcess(_accountingPoint, _consumer, _energySupplier, AsOfYesterday(), _transaction, SystemDateTimeProvider.Now());
 
         Assert.Contains(_accountingPoint.DomainEvents, @event => @event is ConsumerMovedIn);
     }
@@ -55,15 +55,15 @@ public class ConsumerMoveInTests : TestBase
     [Fact]
     public void Throw_if_any_business_rules_are_broken()
     {
-        _consumerMoveInProcess.StartProcess(_accountingPoint, _consumer, _energySupplier, AsOfToday(), _transaction);
+        _consumerMoveInProcess.StartProcess(_accountingPoint, _consumer, _energySupplier, AsOfToday(), _transaction, SystemDateTimeProvider.Now());
 
-        Assert.Throws<BusinessProcessException>(() => _consumerMoveInProcess.StartProcess(_accountingPoint, _consumer, _energySupplier, AsOfToday(), _transaction));
+        Assert.Throws<BusinessProcessException>(() => _consumerMoveInProcess.StartProcess(_accountingPoint, _consumer, _energySupplier, AsOfToday(), _transaction, SystemDateTimeProvider.Now()));
     }
 
     [Fact]
     public void Consumer_move_in_is_accepted()
     {
-        _consumerMoveInProcess.StartProcess(_accountingPoint, _consumer, _energySupplier, AsOfToday(), _transaction);
+        _consumerMoveInProcess.StartProcess(_accountingPoint, _consumer, _energySupplier, AsOfToday(), _transaction, SystemDateTimeProvider.Now());
 
         Assert.Contains(_accountingPoint.DomainEvents, e => e is ConsumerMoveInAccepted);
     }
@@ -73,7 +73,7 @@ public class ConsumerMoveInTests : TestBase
     {
         var moveInDate = AsOfToday();
 
-        _consumerMoveInProcess.StartProcess(_accountingPoint, _consumer, _energySupplier, moveInDate, _transaction);
+        _consumerMoveInProcess.StartProcess(_accountingPoint, _consumer, _energySupplier, moveInDate, _transaction, SystemDateTimeProvider.Now());
 
         var result = CanStartProcess(moveInDate);
 
@@ -84,7 +84,7 @@ public class ConsumerMoveInTests : TestBase
     public void Cannot_register_a_move_in_on_a_date_where_a_move_in_is_already_effectuated()
     {
         var moveInDate = AsOfToday();
-        _consumerMoveInProcess.StartProcess(_accountingPoint, _consumer, _energySupplier, moveInDate, _transaction);
+        _consumerMoveInProcess.StartProcess(_accountingPoint, _consumer, _energySupplier, moveInDate, _transaction, SystemDateTimeProvider.Now());
         _accountingPoint.EffectuateConsumerMoveIn(_transaction, SystemDateTimeProvider.Now());
 
         var result = CanStartProcess(moveInDate);

--- a/source/Processing.Tests/Domain/MeteringPoints/ChangeOfSupplier/AcceptTests.cs
+++ b/source/Processing.Tests/Domain/MeteringPoints/ChangeOfSupplier/AcceptTests.cs
@@ -88,7 +88,7 @@ namespace Processing.Tests.Domain.MeteringPoints.ChangeOfSupplier
             var moveInTransaction = CreateTransaction();
 
             meteringPoint.AcceptConsumerMoveIn(consumerId, energySupplierId, moveInDate, moveInTransaction);
-            meteringPoint.EffectuateConsumerMoveIn(moveInTransaction, _systemDateTimeProvider);
+            meteringPoint.EffectuateConsumerMoveIn(moveInTransaction, _systemDateTimeProvider.Now());
             meteringPoint.AcceptChangeOfSupplier(CreateSupplierId(), _systemDateTimeProvider.Now(), CreateTransaction(), _systemDateTimeProvider);
 
             var result = CanChangeSupplier(meteringPoint);
@@ -142,7 +142,7 @@ namespace Processing.Tests.Domain.MeteringPoints.ChangeOfSupplier
             var moveInDate = _systemDateTimeProvider.Now().Minus(Duration.FromDays(1));
             var moveInTransaction = CreateTransaction();
             meteringPoint.AcceptConsumerMoveIn(consumerId, energySupplierId, moveInDate, moveInTransaction);
-            meteringPoint.EffectuateConsumerMoveIn(moveInTransaction, _systemDateTimeProvider);
+            meteringPoint.EffectuateConsumerMoveIn(moveInTransaction, _systemDateTimeProvider.Now());
 
             meteringPoint.AcceptChangeOfSupplier(CreateSupplierId(), _systemDateTimeProvider.Now(), CreateTransaction(), _systemDateTimeProvider);
 

--- a/source/Processing.Tests/Domain/MeteringPoints/ChangeOfSupplier/CancellationTests.cs
+++ b/source/Processing.Tests/Domain/MeteringPoints/ChangeOfSupplier/CancellationTests.cs
@@ -77,7 +77,7 @@ namespace Processing.Tests.Domain.MeteringPoints.ChangeOfSupplier
             var accountingPoint = new AccountingPoint(GsrnNumber.Create("571234567891234568"), MeteringPointType.Consumption);
             var transaction = CreateTransaction();
             accountingPoint.AcceptConsumerMoveIn(CreateConsumerId(), CreateEnergySupplierId(), _systemDateTimeProvider.Now().Minus(Duration.FromDays(365)), transaction);
-            accountingPoint.EffectuateConsumerMoveIn(transaction, _systemDateTimeProvider);
+            accountingPoint.EffectuateConsumerMoveIn(transaction, _systemDateTimeProvider.Now());
             return (accountingPoint, transaction);
         }
     }

--- a/source/Processing.Tests/Domain/MeteringPoints/ChangeOfSupplier/EffectuateTests.cs
+++ b/source/Processing.Tests/Domain/MeteringPoints/ChangeOfSupplier/EffectuateTests.cs
@@ -82,7 +82,7 @@ namespace Processing.Tests.Domain.MeteringPoints.ChangeOfSupplier
             var accountingPoint = new AccountingPoint(GsrnNumber.Create("571234567891234568"), MeteringPointType.Consumption);
             var transaction = CreateTransaction();
             accountingPoint.AcceptConsumerMoveIn(CreateConsumerId(), CreateEnergySupplierId(), _systemDateTimeProvider.Now().Minus(Duration.FromDays(365)), transaction);
-            accountingPoint.EffectuateConsumerMoveIn(transaction, _systemDateTimeProvider);
+            accountingPoint.EffectuateConsumerMoveIn(transaction, _systemDateTimeProvider.Now());
             return accountingPoint;
         }
     }

--- a/source/Processing.Tests/Domain/MeteringPoints/MoveIn/EffectuateTests.cs
+++ b/source/Processing.Tests/Domain/MeteringPoints/MoveIn/EffectuateTests.cs
@@ -42,7 +42,7 @@ namespace Processing.Tests.Domain.MeteringPoints.MoveIn
             accountingPoint.AcceptConsumerMoveIn(consumerId, energySupplierId, moveInDate, transaction);
 
             Assert.Throws<BusinessProcessException>(() =>
-                accountingPoint.EffectuateConsumerMoveIn(transaction, _systemDateTimeProvider));
+                accountingPoint.EffectuateConsumerMoveIn(transaction, _systemDateTimeProvider.Now()));
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace Processing.Tests.Domain.MeteringPoints.MoveIn
             var nonExistingProcessId = new Transaction("NonExisting");
 
             Assert.Throws<BusinessProcessException>(() =>
-                accountingPoint.EffectuateConsumerMoveIn(nonExistingProcessId, _systemDateTimeProvider));
+                accountingPoint.EffectuateConsumerMoveIn(nonExistingProcessId, _systemDateTimeProvider.Now()));
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace Processing.Tests.Domain.MeteringPoints.MoveIn
             var moveInDate = _systemDateTimeProvider.Now();
             accountingPoint.AcceptConsumerMoveIn(consumerId, energySupplierId, moveInDate, transaction);
 
-            accountingPoint.EffectuateConsumerMoveIn(transaction, _systemDateTimeProvider);
+            accountingPoint.EffectuateConsumerMoveIn(transaction, _systemDateTimeProvider.Now());
 
             Assert.Contains(accountingPoint.DomainEvents, @event => @event is EnergySupplierChanged);
             Assert.Contains(accountingPoint.DomainEvents, @event => @event is ConsumerMovedIn);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description
Effectuate move in immediately when effective date is in the past

