### PR TITLE
Add queue trigger for mp response

### DIFF
--- a/build/infrastructure/main/func-api.tf
+++ b/build/infrastructure/main/func-api.tf
@@ -55,7 +55,7 @@ module "func_receiver" {
     MESSAGE_REQUEST_QUEUE                                         = "@Microsoft.KeyVault(VaultName=${var.shared_resources_keyvault_name};SecretName=sbq-marketroles-name)",
     MOVE_IN_REQUEST_ENDPOINT                                      = "https://func-processing-${lower(var.domain_name_short)}-${lower(var.environment_short)}-${lower(var.environment_instance)}.azurewebsites.net/api/MoveIn"
     SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER = "@Microsoft.KeyVault(VaultName=${var.shared_resources_keyvault_name};SecretName=sb-domain-relay-listen-connection-string)",
-    MASTER_DATA_RESPONSE_QUEUE_NAME                               = data.azurerm_key_vault_secret.sbq_metering_point_master_data_response_name.value
+    METERING_POINT_MASTER_DATA_RESPONSE_QUEUE_NAME                = data.azurerm_key_vault_secret.sbq_metering_point_master_data_response_name.value
   }
 
   tags = azurerm_resource_group.this.tags

--- a/build/infrastructure/main/func-api.tf
+++ b/build/infrastructure/main/func-api.tf
@@ -55,6 +55,9 @@ module "func_receiver" {
     MESSAGE_REQUEST_QUEUE                                         = "@Microsoft.KeyVault(VaultName=${var.shared_resources_keyvault_name};SecretName=sbq-marketroles-name)",
     MOVE_IN_REQUEST_ENDPOINT                                      = "https://func-processing-${lower(var.domain_name_short)}-${lower(var.environment_short)}-${lower(var.environment_instance)}.azurewebsites.net/api/MoveIn"
     SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER = "@Microsoft.KeyVault(VaultName=${var.shared_resources_keyvault_name};SecretName=sb-domain-relay-listen-connection-string)",
+    SERVICE_BUS_CONNECTION_SENDER_STRING                          = "@Microsoft.KeyVault(VaultName=${var.shared_resources_keyvault_name};SecretName=sb-domain-relay-send-connection-string)",
+    MASTER_DATA_RESPONSE_QUEUE_NAME                               = data.azurerm_key_vault_secret.sbq_metering_point_master_data_response_name.value
+    MASTER_DATA_REQUEST_QUEUE_NAME                                = data.azurerm_key_vault_secret.sbq_metering_point_master_data_request_name.value
   }
 
   tags = azurerm_resource_group.this.tags

--- a/build/infrastructure/main/func-api.tf
+++ b/build/infrastructure/main/func-api.tf
@@ -55,9 +55,7 @@ module "func_receiver" {
     MESSAGE_REQUEST_QUEUE                                         = "@Microsoft.KeyVault(VaultName=${var.shared_resources_keyvault_name};SecretName=sbq-marketroles-name)",
     MOVE_IN_REQUEST_ENDPOINT                                      = "https://func-processing-${lower(var.domain_name_short)}-${lower(var.environment_short)}-${lower(var.environment_instance)}.azurewebsites.net/api/MoveIn"
     SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER = "@Microsoft.KeyVault(VaultName=${var.shared_resources_keyvault_name};SecretName=sb-domain-relay-listen-connection-string)",
-    SERVICE_BUS_CONNECTION_SENDER_STRING                          = "@Microsoft.KeyVault(VaultName=${var.shared_resources_keyvault_name};SecretName=sb-domain-relay-send-connection-string)",
     MASTER_DATA_RESPONSE_QUEUE_NAME                               = data.azurerm_key_vault_secret.sbq_metering_point_master_data_response_name.value
-    MASTER_DATA_REQUEST_QUEUE_NAME                                = data.azurerm_key_vault_secret.sbq_metering_point_master_data_request_name.value
   }
 
   tags = azurerm_resource_group.this.tags

--- a/build/infrastructure/main/kv-shared-resources.tf
+++ b/build/infrastructure/main/kv-shared-resources.tf
@@ -77,7 +77,7 @@ data "azurerm_key_vault_secret" "snet_vnet_integrations_id" {
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
 }
 
-data "azurerm_key_vault_secret" "sbq-metering-point-master-data-response-name" {
+data "azurerm_key_vault_secret" "sbq_metering_point_master_data_response_name" {
   name = "sbq-metering-point-master-data-response-name"
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
 }

--- a/build/infrastructure/main/kv-shared-resources.tf
+++ b/build/infrastructure/main/kv-shared-resources.tf
@@ -76,3 +76,8 @@ data "azurerm_key_vault_secret" "snet_vnet_integrations_id" {
   name         = "snet-vnet-integrations-id"
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
 }
+
+data "azurerm_key_vault_secret" "sbq-metering-point-master-data-response-name" {
+  name = "sbq-metering-point-master-data-response-name"
+  key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
+}

--- a/source/Messaging.Api/IncomingMessages/MasterDataResponseListener.cs
+++ b/source/Messaging.Api/IncomingMessages/MasterDataResponseListener.cs
@@ -28,7 +28,7 @@ public class MasterDataResponseListener
     }
 
     [Function("MasterDataResponseListener")]
-    public void Run([ServiceBusTrigger("%MASTER_DATA_RESPONSE_QUEUE_NAME%", Connection = "MASTER_DATA_RESPONSE_QUEUE_CONNECTION_STRING")] byte[] data, FunctionContext context)
+    public void Run([ServiceBusTrigger("%MASTER_DATA_RESPONSE_QUEUE_NAME%", Connection = "SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER")] byte[] data, FunctionContext context)
     {
         if (data == null) throw new ArgumentNullException(nameof(data));
         if (context == null) throw new ArgumentNullException(nameof(context));

--- a/source/Messaging.Api/IncomingMessages/MasterDataResponseListener.cs
+++ b/source/Messaging.Api/IncomingMessages/MasterDataResponseListener.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace Messaging.Api.IncomingMessages;
+
+public class MasterDataResponseListener
+{
+    private readonly ILogger<MasterDataResponseListener> _logger;
+
+    public MasterDataResponseListener(ILogger<MasterDataResponseListener> logger)
+    {
+        _logger = logger;
+    }
+
+    [Function("MasterDataResponseListener")]
+    public void Run([ServiceBusTrigger("%MASTER_DATA_RESPONSE_QUEUE_NAME%", Connection = "MASTER_DATA_RESPONSE_QUEUE_CONNECTION_STRING")] byte[] data, FunctionContext context)
+    {
+        if (data == null) throw new ArgumentNullException(nameof(data));
+        if (context == null) throw new ArgumentNullException(nameof(context));
+
+        _logger.LogInformation($"C# ServiceBus queue trigger function processed message: {data}");
+    }
+}

--- a/source/Messaging.Api/IncomingMessages/MeteringPointMasterDataResponseListener.cs
+++ b/source/Messaging.Api/IncomingMessages/MeteringPointMasterDataResponseListener.cs
@@ -18,21 +18,21 @@ using Microsoft.Extensions.Logging;
 
 namespace Messaging.Api.IncomingMessages;
 
-public class MasterDataResponseListener
+public class MeteringPointMasterDataResponseListener
 {
-    private readonly ILogger<MasterDataResponseListener> _logger;
+    private readonly ILogger<MeteringPointMasterDataResponseListener> _logger;
 
-    public MasterDataResponseListener(ILogger<MasterDataResponseListener> logger)
+    public MeteringPointMasterDataResponseListener(ILogger<MeteringPointMasterDataResponseListener> logger)
     {
         _logger = logger;
     }
 
-    [Function("MasterDataResponseListener")]
-    public void Run([ServiceBusTrigger("%MASTER_DATA_RESPONSE_QUEUE_NAME%", Connection = "SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER")] byte[] data, FunctionContext context)
+    [Function("MeteringPointMasterDataResponseListener")]
+    public void Run([ServiceBusTrigger("%METERING_POINT_MASTER_DATA_RESPONSE_QUEUE_NAME%", Connection = "SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER")] byte[] data, FunctionContext context)
     {
         if (data == null) throw new ArgumentNullException(nameof(data));
         if (context == null) throw new ArgumentNullException(nameof(context));
 
-        _logger.LogInformation($"C# ServiceBus queue trigger function processed message: {data}");
+        _logger.LogInformation($"Master data response received: {data}");
     }
 }

--- a/source/Messaging.Api/local.settings.sample.json
+++ b/source/Messaging.Api/local.settings.sample.json
@@ -21,6 +21,6 @@
     "MESSAGE_REQUEST_QUEUE": "<Queue for post office to request bundle>",
     "MOVE_IN_REQUEST_ENDPOINT": "<Move in request url>",
     "SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER": "<service bus connection string for integration events listener permissions>",
-    "MASTER_DATA_RESPONSE_QUEUE_NAME": "<Master data response queue name>",
+    "METERING_POINT_MASTER_DATA_RESPONSE_QUEUE_NAME": "<Master data response queue name>"
   }
 }

--- a/source/Messaging.Api/local.settings.sample.json
+++ b/source/Messaging.Api/local.settings.sample.json
@@ -20,6 +20,8 @@
     "MESSAGEHUB_DOMAIN_REPLY_QUEUE": "<MessageHub Domain Reply Queue name>",
     "MESSAGE_REQUEST_QUEUE": "<Queue for post office to request bundle>",
     "MOVE_IN_REQUEST_ENDPOINT": "<Move in request url>",
-    "SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER": "<service bus connection string for integration events listener permissions>"
+    "SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER": "<service bus connection string for integration events listener permissions>",
+    "MASTER_DATA_RESPONSE_QUEUE_NAME": "<Master data response queue name>",
+    "MASTER_DATA_RESPONSE_QUEUE_CONNECTION_STRING": "<Master data response queue connection string>"
   }
 }

--- a/source/Messaging.Api/local.settings.sample.json
+++ b/source/Messaging.Api/local.settings.sample.json
@@ -23,6 +23,5 @@
     "SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER": "<service bus connection string for integration events listener permissions>",
     "SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER": "<service bus connection string for integration events listener permissions>",
     "MASTER_DATA_RESPONSE_QUEUE_NAME": "<Master data response queue name>",
-    "MASTER_DATA_RESPONSE_QUEUE_CONNECTION_STRING": "<Master data response queue connection string>"
   }
 }

--- a/source/Messaging.Api/local.settings.sample.json
+++ b/source/Messaging.Api/local.settings.sample.json
@@ -21,7 +21,6 @@
     "MESSAGE_REQUEST_QUEUE": "<Queue for post office to request bundle>",
     "MOVE_IN_REQUEST_ENDPOINT": "<Move in request url>",
     "SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER": "<service bus connection string for integration events listener permissions>",
-    "SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER": "<service bus connection string for integration events listener permissions>",
     "MASTER_DATA_RESPONSE_QUEUE_NAME": "<Master data response queue name>",
   }
 }

--- a/source/Messaging.Api/local.settings.sample.json
+++ b/source/Messaging.Api/local.settings.sample.json
@@ -21,6 +21,7 @@
     "MESSAGE_REQUEST_QUEUE": "<Queue for post office to request bundle>",
     "MOVE_IN_REQUEST_ENDPOINT": "<Move in request url>",
     "SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER": "<service bus connection string for integration events listener permissions>",
+    "SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER": "<service bus connection string for integration events listener permissions>",
     "MASTER_DATA_RESPONSE_QUEUE_NAME": "<Master data response queue name>",
     "MASTER_DATA_RESPONSE_QUEUE_CONNECTION_STRING": "<Master data response queue connection string>"
   }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description

Adds a new queue trigger for receiving response to master data requests from MP domain

Adds new configuration for retreiving queue name from KV
