### PR TITLE
Add ProcessId to Transaction

### DIFF
--- a/source/Messaging.Application/Transactions/MoveIn/MoveInTransaction.cs
+++ b/source/Messaging.Application/Transactions/MoveIn/MoveInTransaction.cs
@@ -61,7 +61,7 @@ namespace Messaging.Application.Transactions.MoveIn
             {
                 ProcessId = businessRequestResult.ProcessId;
                 _state = State.Started;
-                _domainEvents.Add(new PendingBusinessProcess() { ProcessId = ProcessId! });
+                _domainEvents.Add(new PendingBusinessProcess(ProcessId!));
             }
         }
 

--- a/source/Messaging.Application/Transactions/MoveIn/MoveInTransaction.cs
+++ b/source/Messaging.Application/Transactions/MoveIn/MoveInTransaction.cs
@@ -59,8 +59,9 @@ namespace Messaging.Application.Transactions.MoveIn
             }
             else
             {
+                ProcessId = businessRequestResult.ProcessId;
                 _state = State.Started;
-                _domainEvents.Add(new PendingBusinessProcess());
+                _domainEvents.Add(new PendingBusinessProcess() { ProcessId = ProcessId! });
             }
         }
 

--- a/source/Messaging.Application/Transactions/MoveIn/PendingBusinessProcess.cs
+++ b/source/Messaging.Application/Transactions/MoveIn/PendingBusinessProcess.cs
@@ -16,4 +16,5 @@ namespace Messaging.Application.Transactions.MoveIn;
 
 public class PendingBusinessProcess
 {
+    public string? ProcessId { get; set; }
 }

--- a/source/Messaging.Application/Transactions/MoveIn/PendingBusinessProcess.cs
+++ b/source/Messaging.Application/Transactions/MoveIn/PendingBusinessProcess.cs
@@ -12,9 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+
 namespace Messaging.Application.Transactions.MoveIn;
 
 public class PendingBusinessProcess
 {
-    public string? ProcessId { get; set; }
+    public PendingBusinessProcess(string processId)
+    {
+        if (processId == null) throw new ArgumentNullException(nameof(processId));
+        ProcessId = processId;
+    }
+
+    public string ProcessId { get; }
 }

--- a/source/Messaging.IntegrationTests/Application/Transactions/MoveIn/AssertTransaction.cs
+++ b/source/Messaging.IntegrationTests/Application/Transactions/MoveIn/AssertTransaction.cs
@@ -16,6 +16,7 @@ using System;
 using Dapper;
 using Messaging.Application.Configuration.DataAccess;
 using Messaging.Application.Transactions.MoveIn;
+using Processing.Domain.MeteringPoints;
 using Xunit;
 
 namespace Messaging.IntegrationTests.Application.Transactions.MoveIn;
@@ -49,6 +50,13 @@ public class AssertTransaction
     public AssertTransaction HasState(MoveInTransaction.State expectedState)
     {
         Assert.Equal(expectedState.ToString(), _transaction.State);
+        return this;
+    }
+
+    public AssertTransaction HasProcessId(string expectedProcessId)
+    {
+        Assert.NotNull(_transaction.ProcessId);
+        Assert.Equal(expectedProcessId, _transaction.ProcessId);
         return this;
     }
 }

--- a/source/Messaging.IntegrationTests/Application/Transactions/MoveIn/AssertTransaction.cs
+++ b/source/Messaging.IntegrationTests/Application/Transactions/MoveIn/AssertTransaction.cs
@@ -55,7 +55,6 @@ public class AssertTransaction
 
     public AssertTransaction HasProcessId(string expectedProcessId)
     {
-        Assert.NotNull(_transaction.ProcessId);
         Assert.Equal(expectedProcessId, _transaction.ProcessId);
         return this;
     }

--- a/source/Messaging.IntegrationTests/Application/Transactions/MoveIn/CompleteMoveInTests.cs
+++ b/source/Messaging.IntegrationTests/Application/Transactions/MoveIn/CompleteMoveInTests.cs
@@ -46,10 +46,11 @@ public class CompleteMoveInTests : TestBase
     [Fact]
     public async Task Transaction_is_completed()
     {
-        await CompleteMoveIn().ConfigureAwait(false);
+        var transaction = await CompleteMoveIn().ConfigureAwait(false);
 
         AssertTransaction.Transaction(SampleData.TransactionId, GetService<IDbConnectionFactory>())
-            .HasState(MoveInTransaction.State.Completed);
+            .HasState(MoveInTransaction.State.Completed)
+            .HasProcessId(transaction.ProcessId!);
     }
 
     [Fact]

--- a/source/Messaging.Tests/Transactions/MoveIn/MoveInTransactionTests.cs
+++ b/source/Messaging.Tests/Transactions/MoveIn/MoveInTransactionTests.cs
@@ -34,7 +34,7 @@ public class MoveInTransactionTests
         Assert.Equal(1, transaction.DomainEvents.Count);
         Assert.Contains(transaction.DomainEvents, e => e is PendingBusinessProcess);
 
-        AssertProcessId(transaction);
+        AssertProcessId(requestResult, transaction);
     }
 
     [Fact]
@@ -84,10 +84,9 @@ public class MoveInTransactionTests
         return BusinessRequestResult.Succeeded(Guid.NewGuid().ToString());
     }
 
-    private static void AssertProcessId(MoveInTransaction transaction)
+    private static void AssertProcessId(BusinessRequestResult requestResult, MoveInTransaction transaction)
     {
         var pendingBusinessProcess = transaction.DomainEvents.First() as PendingBusinessProcess;
-        Assert.NotNull(pendingBusinessProcess?.ProcessId);
-        Assert.Equal(pendingBusinessProcess?.ProcessId, transaction.ProcessId);
+        Assert.Equal(pendingBusinessProcess?.ProcessId, requestResult.ProcessId);
     }
 }

--- a/source/Messaging.Tests/Transactions/MoveIn/MoveInTransactionTests.cs
+++ b/source/Messaging.Tests/Transactions/MoveIn/MoveInTransactionTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Linq;
 using Messaging.Application.Transactions;
 using Messaging.Application.Transactions.MoveIn;
 using NodaTime;
@@ -32,6 +33,8 @@ public class MoveInTransactionTests
 
         Assert.Equal(1, transaction.DomainEvents.Count);
         Assert.Contains(transaction.DomainEvents, e => e is PendingBusinessProcess);
+
+        AssertProcessId(transaction);
     }
 
     [Fact]
@@ -79,5 +82,12 @@ public class MoveInTransactionTests
     private static BusinessRequestResult BusinessRequestSucceeded()
     {
         return BusinessRequestResult.Succeeded(Guid.NewGuid().ToString());
+    }
+
+    private static void AssertProcessId(MoveInTransaction transaction)
+    {
+        var pendingBusinessProcess = transaction.DomainEvents.First() as PendingBusinessProcess;
+        Assert.NotNull(pendingBusinessProcess?.ProcessId);
+        Assert.Equal(pendingBusinessProcess?.ProcessId, transaction.ProcessId);
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description

Set ProcessId on MoveInTransaction on transaction start
Added test to ensure ProcessId matches that of BusinessRequestResult

