### PR TITLE
Added duplicate key checks

### DIFF
--- a/source/Energinet.DataHub.MarketRoles.ApplyDBMigrationsApp/Scripts/Seed/202206281101 Insert Reasons.sql
+++ b/source/Energinet.DataHub.MarketRoles.ApplyDBMigrationsApp/Scripts/Seed/202206281101 Insert Reasons.sql
@@ -1,14 +1,129 @@
-INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode) VALUES (N'EF0BED27-D076-495B-9819-3C55E9B1E50A', N'ConsumerNameIsRequired', N'D64', N'Kundenavn er påkrævet', N'dk');
-INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode) VALUES (N'8A9F0DE5-5C07-4E73-977E-5225E264646A', N'ConsumerNameIsRequired', N'D64', N'Customer name is required', N'en');
-INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode) VALUES (N'8CE12145-18E3-4B43-B546-02EFD07A98D9', N'UnknownAccountingPoint', N'E10', N'Målepunktet eksisterer ikke eller er ikke et forbrugs eller produktions målepunkt', N'dk');
-INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode) VALUES (N'5DD22A72-1E16-444F-B59B-DAFC93EF1E7D', N'UnknownAccountingPoint', N'E10', N'Metering point does not exist or is not a consumption or production metering point', N'en');
-INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode) VALUES (N'97EE4769-4357-4B33-B3EA-49F1F832281E', N'ConsumerIdentifierIsRequired', N'D64', N'Kunde ID er påkrævet', N'dk');
-INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode) VALUES (N'BA0D36F1-EC08-4957-8EDE-130237B0171B', N'ConsumerIdentifierIsRequired', N'D64', N'Customer ID is required', N'en');
-INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode) VALUES (N'3E1AECE5-7EFB-4E56-82CE-278EEA2CE157', N'EffectiveDateIsNotWithinAllowedTimePeriod', N'E17', N'Startdatoen er ikke modtaget indenfor den korrekte tidsperiode', N'dk');
-INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode) VALUES (N'A3EBC763-D8B5-4C23-96C2-1B1FDB87BC56', N'EffectiveDateIsNotWithinAllowedTimePeriod', N'E17', N'The startdate is not received within the correct timeframe', N'en');
-INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode) VALUES (N'6D608489-7267-41DC-9187-66338202E7FA', N'InvalidEffectiveDateTimeOfDay', N'D66', N'Startdato for målepunktet skal have UTC+0 med formatet YYYY-MM-DD 00:00', N'dk');
-INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode) VALUES (N'B5AA3770-A06B-4C51-AADC-C386CF009BF2', N'InvalidEffectiveDateTimeOfDay', N'D66', N'Date time for the metering point must have UTC+0 equivalent of local format YYYY-MM-DD 00:00:00', N'en');
-INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode) VALUES (N'F82A727B-5AC0-4366-A0A9-B64C5613A466', N'GsrnNumberIsRequired', N'D64', N'Målepunkts ID er påkrævet', N'dk');
-INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode) VALUES (N'82798ED1-9741-4CA3-9F0E-6DC58B8B64D1', N'GsrnNumberIsRequired', N'D64', N'Metering point ID is required', N'en');
-INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode) VALUES (N'0565A09A-794E-4653-8302-7CFA0ABAFB67', N'InvalidGsrnNumber', N'E10', N'Målepunktet er ikke et valid målepunkt, er ikke et EAN18, forkert tjeksum eller starter ikke med 57', N'dk');
-INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode) VALUES (N'12B4DB54-B22C-41AA-BA20-358F75B31FA8', N'InvalidGsrnNumber', N'E10', N'Metering point ID is not a valid GSRN/EAN18 code (wrong checksum) or does not start with digits 57', N'en');
+IF (SELECT Id
+    FROM [b2b].[ReasonTranslations]
+    WHERE Id = N'EF0BED27-D076-495B-9819-3C55E9B1E50A') IS NULL
+    BEGIN
+        INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode)
+        VALUES (N'EF0BED27-D076-495B-9819-3C55E9B1E50A', N'ConsumerNameIsRequired', N'D64', N'Kundenavn er påkrævet',
+                N'dk');
+    END
+GO
+IF (SELECT Id
+    FROM [b2b].[ReasonTranslations]
+    WHERE Id = N'8A9F0DE5-5C07-4E73-977E-5225E264646A') IS NULL
+    BEGIN
+        INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode)
+        VALUES (N'8A9F0DE5-5C07-4E73-977E-5225E264646A', N'ConsumerNameIsRequired', N'D64',
+                N'Customer name is required', N'en');
+    END
+GO
+IF (SELECT Id
+    FROM [b2b].[ReasonTranslations]
+    WHERE Id = N'8CE12145-18E3-4B43-B546-02EFD07A98D9') IS NULL
+    BEGIN
+        INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode)
+        VALUES (N'8CE12145-18E3-4B43-B546-02EFD07A98D9', N'UnknownAccountingPoint', N'E10',
+                N'Målepunktet eksisterer ikke eller er ikke et forbrugs eller produktions målepunkt', N'dk');
+    END
+GO
+IF (SELECT Id
+    FROM [b2b].[ReasonTranslations]
+    WHERE Id = N'5DD22A72-1E16-444F-B59B-DAFC93EF1E7D') IS NULL
+    BEGIN
+        INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode)
+        VALUES (N'5DD22A72-1E16-444F-B59B-DAFC93EF1E7D', N'UnknownAccountingPoint', N'E10',
+                N'Metering point does not exist or is not a consumption or production metering point', N'en');
+    END
+GO
+IF (SELECT Id
+    FROM [b2b].[ReasonTranslations]
+    WHERE Id = N'97EE4769-4357-4B33-B3EA-49F1F832281E') IS NULL
+    BEGIN
+        INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode)
+        VALUES (N'97EE4769-4357-4B33-B3EA-49F1F832281E', N'ConsumerIdentifierIsRequired', N'D64',
+                N'Kunde ID er påkrævet', N'dk');
+    END
+GO
+IF (SELECT Id
+    FROM [b2b].[ReasonTranslations]
+    WHERE Id = N'BA0D36F1-EC08-4957-8EDE-130237B0171B') IS NULL
+    BEGIN
+        INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode)
+        VALUES (N'BA0D36F1-EC08-4957-8EDE-130237B0171B', N'ConsumerIdentifierIsRequired', N'D64',
+                N'Customer ID is required', N'en');
+    END
+GO
+IF (SELECT Id
+    FROM [b2b].[ReasonTranslations]
+    WHERE Id = N'3E1AECE5-7EFB-4E56-82CE-278EEA2CE157') IS NULL
+    BEGIN
+        INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode)
+        VALUES (N'3E1AECE5-7EFB-4E56-82CE-278EEA2CE157', N'EffectiveDateIsNotWithinAllowedTimePeriod', N'E17',
+                N'Startdatoen er ikke modtaget indenfor den korrekte tidsperiode', N'dk');
+    END
+GO
+IF (SELECT Id
+    FROM [b2b].[ReasonTranslations]
+    WHERE Id = N'A3EBC763-D8B5-4C23-96C2-1B1FDB87BC56') IS NULL
+    BEGIN
+        INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode)
+        VALUES (N'A3EBC763-D8B5-4C23-96C2-1B1FDB87BC56', N'EffectiveDateIsNotWithinAllowedTimePeriod', N'E17',
+                N'The startdate is not received within the correct timeframe', N'en');
+    END
+GO
+IF (SELECT Id
+    FROM [b2b].[ReasonTranslations]
+    WHERE Id = N'6D608489-7267-41DC-9187-66338202E7FA') IS NULL
+    BEGIN
+        INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode)
+        VALUES (N'6D608489-7267-41DC-9187-66338202E7FA', N'InvalidEffectiveDateTimeOfDay', N'D66',
+                N'Startdato for målepunktet skal have UTC+0 med formatet YYYY-MM-DD 00:00', N'dk');
+    END
+GO
+IF (SELECT Id
+    FROM [b2b].[ReasonTranslations]
+    WHERE Id = N'B5AA3770-A06B-4C51-AADC-C386CF009BF2') IS NULL
+    BEGIN
+        INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode)
+        VALUES (N'B5AA3770-A06B-4C51-AADC-C386CF009BF2', N'InvalidEffectiveDateTimeOfDay', N'D66',
+                N'Date time for the metering point must have UTC+0 equivalent of local format YYYY-MM-DD 00:00:00',
+                N'en');
+    END
+GO
+IF (SELECT Id
+    FROM [b2b].[ReasonTranslations]
+    WHERE Id = N'F82A727B-5AC0-4366-A0A9-B64C5613A466') IS NULL
+    BEGIN
+        INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode)
+        VALUES (N'F82A727B-5AC0-4366-A0A9-B64C5613A466', N'GsrnNumberIsRequired', N'D64', N'Målepunkts ID er påkrævet',
+                N'dk');
+    END
+GO
+IF (SELECT Id
+    FROM [b2b].[ReasonTranslations]
+    WHERE Id = N'82798ED1-9741-4CA3-9F0E-6DC58B8B64D1') IS NULL
+    BEGIN
+        INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode)
+        VALUES (N'82798ED1-9741-4CA3-9F0E-6DC58B8B64D1', N'GsrnNumberIsRequired', N'D64',
+                N'Metering point ID is required', N'en');
+    END
+GO
+IF (SELECT Id
+    FROM [b2b].[ReasonTranslations]
+    WHERE Id = N'0565A09A-794E-4653-8302-7CFA0ABAFB67') IS NULL
+    BEGIN
+        INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode)
+        VALUES (N'0565A09A-794E-4653-8302-7CFA0ABAFB67', N'InvalidGsrnNumber', N'E10',
+                N'Målepunktet er ikke et valid målepunkt, er ikke et EAN18, forkert tjeksum eller starter ikke med 57',
+                N'dk');
+    END
+GO
+IF (SELECT Id
+    FROM [b2b].[ReasonTranslations]
+    WHERE Id = N'12B4DB54-B22C-41AA-BA20-358F75B31FA8') IS NULL
+    BEGIN
+        INSERT INTO [b2b].[ReasonTranslations] (Id, ErrorCode, Code, Text, LanguageCode)
+        VALUES (N'12B4DB54-B22C-41AA-BA20-358F75B31FA8', N'InvalidGsrnNumber', N'E10',
+                N'Metering point ID is not a valid GSRN/EAN18 code (wrong checksum) or does not start with digits 57',
+                N'en');
+    END
+GO

--- a/source/Energinet.DataHub.MarketRoles.ApplyDBMigrationsApp/Scripts/Seed/202206281102 Insert AccountPoints.sql
+++ b/source/Energinet.DataHub.MarketRoles.ApplyDBMigrationsApp/Scripts/Seed/202206281102 Insert AccountPoints.sql
@@ -1,16 +1,128 @@
-﻿INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'B7586A8F-95E4-4BCB-BE52-4063C54A965A', N'571313180400013018', 0, 0, 0);
-INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'829E71BD-05AB-41B1-BFC8-64AA5432FC47', N'571313180400013025', 0, 0, 1);
-INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'E4B561FE-0DE0-4131-8ACB-3E253DC93EA8', N'571313180400013032', 0, 0, 0);
-INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'F3F1C64B-41F5-4DD8-96FD-00FF89CCF8F9', N'571313180400013049', 0, 0, 0);
-INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'2ED92A1D-11FD-4B85-A721-2AEC247BD9A1', N'571313180400013056', 0, 0, 1);
-INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'CAB7038D-AB4E-4C60-AEB4-8E3E409D7526', N'571313180400021143', 0, 0, 0);
-INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'D93480B6-9945-4504-95D2-DA4DFFF11124', N'571313180400021150', 0, 0, 1);
-INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'E6160B69-DF2C-4BBF-BBC8-54C3DBD7C718', N'571313180400021396', 0, 0, 0);
-INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'1FB043FE-5963-4383-85AE-54CA0557A832', N'571313180400021440', 0, 0, 0);
-INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'6944D40E-4ACC-44F9-A35C-256CEA954E6C', N'571313180400021280', 0, 0, 0);
-INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'9E113361-DF7F-4384-B0F1-C808DA894C4B', N'571313180400021556', 0, 0, 0);
-INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'B597E13F-4B76-44BD-A354-2C6278EE6451', N'571313180400021563', 0, 0, 1);
-INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'0ABD46EB-DFD7-4A1A-A882-E033CAC1A2DE', N'575774240560385464', 0, 0, 0);
-INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'D72E472A-7020-4E42-8A53-B54E81997F79', N'576472056330924540', 0, 0, 0);
-INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'4CB80D3E-7CA6-4CC8-B4BB-91F0E18BB5D9', N'574591757409421563', 0, 0, 1);
-INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type) VALUES (N'085FA099-DCC1-44CB-AD80-930B040B343E', N'576354778588349757', 0, 0, 0);
+﻿IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'B7586A8F-95E4-4BCB-BE52-4063C54A965A') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'B7586A8F-95E4-4BCB-BE52-4063C54A965A', N'571313180400013018', 0, 0, 0)
+    END
+GO
+IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'829E71BD-05AB-41B1-BFC8-64AA5432FC47') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'829E71BD-05AB-41B1-BFC8-64AA5432FC47', N'571313180400013025', 0, 0, 1);
+    END
+GO
+IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'E4B561FE-0DE0-4131-8ACB-3E253DC93EA8') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'E4B561FE-0DE0-4131-8ACB-3E253DC93EA8', N'571313180400013032', 0, 0, 0);
+    END
+GO
+IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'F3F1C64B-41F5-4DD8-96FD-00FF89CCF8F9') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'F3F1C64B-41F5-4DD8-96FD-00FF89CCF8F9', N'571313180400013049', 0, 0, 0);
+    END
+GO
+IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'2ED92A1D-11FD-4B85-A721-2AEC247BD9A1') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'2ED92A1D-11FD-4B85-A721-2AEC247BD9A1', N'571313180400013056', 0, 0, 1);
+    END
+GO
+IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'CAB7038D-AB4E-4C60-AEB4-8E3E409D7526') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'CAB7038D-AB4E-4C60-AEB4-8E3E409D7526', N'571313180400021143', 0, 0, 0);
+    END
+GO
+IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'D93480B6-9945-4504-95D2-DA4DFFF11124') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'D93480B6-9945-4504-95D2-DA4DFFF11124', N'571313180400021150', 0, 0, 1);
+    END
+GO
+IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'E6160B69-DF2C-4BBF-BBC8-54C3DBD7C718') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'E6160B69-DF2C-4BBF-BBC8-54C3DBD7C718', N'571313180400021396', 0, 0, 0);
+    END
+GO
+IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'1FB043FE-5963-4383-85AE-54CA0557A832') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'1FB043FE-5963-4383-85AE-54CA0557A832', N'571313180400021440', 0, 0, 0);
+    END
+GO
+IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'6944D40E-4ACC-44F9-A35C-256CEA954E6C') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'6944D40E-4ACC-44F9-A35C-256CEA954E6C', N'571313180400021280', 0, 0, 0);
+    END
+GO
+IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'9E113361-DF7F-4384-B0F1-C808DA894C4B') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'9E113361-DF7F-4384-B0F1-C808DA894C4B', N'571313180400021556', 0, 0, 0);
+    END
+GO
+IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'B597E13F-4B76-44BD-A354-2C6278EE6451') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'B597E13F-4B76-44BD-A354-2C6278EE6451', N'571313180400021563', 0, 0, 1);
+    END
+GO
+IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'0ABD46EB-DFD7-4A1A-A882-E033CAC1A2DE') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'0ABD46EB-DFD7-4A1A-A882-E033CAC1A2DE', N'575774240560385464', 0, 0, 0);
+    END
+GO
+IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'D72E472A-7020-4E42-8A53-B54E81997F79') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'D72E472A-7020-4E42-8A53-B54E81997F79', N'576472056330924540', 0, 0, 0);
+    END
+GO
+IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'4CB80D3E-7CA6-4CC8-B4BB-91F0E18BB5D9') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'4CB80D3E-7CA6-4CC8-B4BB-91F0E18BB5D9', N'574591757409421563', 0, 0, 1);
+    END
+GO
+IF (SELECT Id
+    FROM [dbo].[AccountingPoints]
+    WHERE Id = N'085FA099-DCC1-44CB-AD80-930B040B343E') IS NULL
+    BEGIN
+        INSERT INTO [dbo].[AccountingPoints] (Id, GsrnNumber, ProductionObligated, PhysicalState, Type)
+        VALUES (N'085FA099-DCC1-44CB-AD80-930B040B343E', N'576354778588349757', 0, 0, 0);
+    END
+GO


### PR DESCRIPTION
The new seeds scripts caused duplicate key errors when executing since the data was already present in the database due to previously executed scripts. Now the data only gets added if it isn't already present.