### PR TITLE
Variable CIM type

### DIFF
--- a/source/Messaging.Application/Common/HeaderWriter.cs
+++ b/source/Messaging.Application/Common/HeaderWriter.cs
@@ -41,7 +41,7 @@ public static class HeaderWriter
                 documentDetails.SchemaLocation)
             .ConfigureAwait(false);
         await writer.WriteElementStringAsync(documentDetails.Prefix, "mRID", null, messageHeader.MessageId).ConfigureAwait(false);
-        await writer.WriteElementStringAsync(documentDetails.Prefix, "type", null, "414").ConfigureAwait(false);
+        await writer.WriteElementStringAsync(documentDetails.Prefix, "type", null, messageHeader.Type).ConfigureAwait(false);
         await writer.WriteElementStringAsync(documentDetails.Prefix, "process.processType", null, messageHeader.ProcessType)
             .ConfigureAwait(false);
         await writer.WriteElementStringAsync(documentDetails.Prefix, "businessSector.type", null, "23").ConfigureAwait(false);

--- a/source/Messaging.Application/Common/HeaderWriter.cs
+++ b/source/Messaging.Application/Common/HeaderWriter.cs
@@ -41,7 +41,7 @@ public static class HeaderWriter
                 documentDetails.SchemaLocation)
             .ConfigureAwait(false);
         await writer.WriteElementStringAsync(documentDetails.Prefix, "mRID", null, messageHeader.MessageId).ConfigureAwait(false);
-        await writer.WriteElementStringAsync(documentDetails.Prefix, "type", null, "E44").ConfigureAwait(false);
+        await writer.WriteElementStringAsync(documentDetails.Prefix, "type", null, "414").ConfigureAwait(false);
         await writer.WriteElementStringAsync(documentDetails.Prefix, "process.processType", null, messageHeader.ProcessType)
             .ConfigureAwait(false);
         await writer.WriteElementStringAsync(documentDetails.Prefix, "businessSector.type", null, "23").ConfigureAwait(false);

--- a/source/Messaging.Application/OutgoingMessages/DocumentNameCode.cs
+++ b/source/Messaging.Application/OutgoingMessages/DocumentNameCode.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using Messaging.Domain.SeedWork;
+
+namespace Messaging.Application.OutgoingMessages;
+
+public sealed class DocumentNameCode : EnumerationType
+{
+    public static readonly DocumentNameCode ConfirmationOfStartOfSupply = new(
+        0,
+        nameof(ConfirmationOfStartOfSupply),
+        "414");
+
+    public static readonly DocumentNameCode NotificationToSupplier = new(
+        1,
+        nameof(NotificationToSupplier),
+        "E44");
+
+    private DocumentNameCode(int id, string name, string code)
+        : base(id, name)
+    {
+        Code = code;
+    }
+
+    public string Code { get; }
+}

--- a/source/Messaging.Application/OutgoingMessages/MessageFactory.cs
+++ b/source/Messaging.Application/OutgoingMessages/MessageFactory.cs
@@ -49,6 +49,15 @@ public class MessageFactory
 
     private MessageHeader CreateMessageHeaderFrom(OutgoingMessage message)
     {
-        return new MessageHeader(message.ProcessType, message.SenderId, message.SenderRole, message.ReceiverId, message.ReceiverRole, MessageIdGenerator.Generate(), _systemDateTimeProvider.Now(), message.ReasonCode);
+        return new MessageHeader(
+            message.ProcessType,
+            message.Type,
+            message.SenderId,
+            message.SenderRole,
+            message.ReceiverId,
+            message.ReceiverRole,
+            MessageIdGenerator.Generate(),
+            _systemDateTimeProvider.Now(),
+            message.ReasonCode);
     }
 }

--- a/source/Messaging.Application/OutgoingMessages/MessageHeader.cs
+++ b/source/Messaging.Application/OutgoingMessages/MessageHeader.cs
@@ -18,6 +18,7 @@ namespace Messaging.Application.OutgoingMessages
 {
     public record MessageHeader(
         string ProcessType,
+        string Type,
         string SenderId,
         string SenderRole,
         string ReceiverId,

--- a/source/Messaging.Application/OutgoingMessages/OutgoingMessage.cs
+++ b/source/Messaging.Application/OutgoingMessages/OutgoingMessage.cs
@@ -18,7 +18,18 @@ namespace Messaging.Application.OutgoingMessages
 {
     public class OutgoingMessage
     {
-        public OutgoingMessage(string documentType, string receiverId, string correlationId, string originalMessageId, string processType, string receiverRole, string senderId, string senderRole, string marketActivityRecordPayload, string? reasonCode)
+        public OutgoingMessage(
+            string documentType,
+            string type,
+            string receiverId,
+            string correlationId,
+            string originalMessageId,
+            string processType,
+            string receiverRole,
+            string senderId,
+            string senderRole,
+            string marketActivityRecordPayload,
+            string? reasonCode)
         {
             DocumentType = documentType;
             ReceiverId = receiverId;
@@ -30,12 +41,26 @@ namespace Messaging.Application.OutgoingMessages
             SenderRole = senderRole;
             MarketActivityRecordPayload = marketActivityRecordPayload;
             ReasonCode = reasonCode;
+            Type = type;
             Id = Guid.NewGuid();
         }
 
-        private OutgoingMessage(Guid id, string documentType, string receiverId, string correlationId, string originalMessageId, string processType, string receiverRole, string senderId, string senderRole, string marketActivityRecordPayload, string? reasonCode)
+        private OutgoingMessage(
+            Guid id,
+            string documentType,
+            string type,
+            string receiverId,
+            string correlationId,
+            string originalMessageId,
+            string processType,
+            string receiverRole,
+            string senderId,
+            string senderRole,
+            string marketActivityRecordPayload,
+            string? reasonCode)
         {
             DocumentType = documentType;
+            Type = type;
             ReceiverId = receiverId;
             CorrelationId = correlationId;
             OriginalMessageId = originalMessageId;
@@ -55,6 +80,8 @@ namespace Messaging.Application.OutgoingMessages
         public string ReceiverId { get; }
 
         public string DocumentType { get; }
+
+        public string Type { get; }
 
         public string? ReasonCode { get; }
 

--- a/source/Messaging.Application/Transactions/MoveIn/MoveInNotifications.cs
+++ b/source/Messaging.Application/Transactions/MoveIn/MoveInNotifications.cs
@@ -51,6 +51,7 @@ public class MoveInNotifications
 
         var message = new OutgoingMessage(
             DocumentType.GenericNotification.ToString(),
+            DocumentNameCode.NotificationToSupplier.Code,
             transaction.CurrentEnergySupplierId,
             Guid.NewGuid().ToString(),
             transaction.TransactionId,

--- a/source/Messaging.Application/Transactions/MoveIn/MoveInRequestHandler.cs
+++ b/source/Messaging.Application/Transactions/MoveIn/MoveInRequestHandler.cs
@@ -102,7 +102,7 @@ namespace Messaging.Application.Transactions.MoveIn
             if (!string.IsNullOrEmpty(consumerIdType))
             {
                 consumerType =
-                   consumerIdType.Equals(cprNumberTypeIdentifier, StringComparison.OrdinalIgnoreCase)
+                    consumerIdType.Equals(cprNumberTypeIdentifier, StringComparison.OrdinalIgnoreCase)
                         ? "CPR"
                         : "CVR";
             }
@@ -132,6 +132,7 @@ namespace Messaging.Application.Transactions.MoveIn
             return CreateOutgoingMessage(
                 transaction.StartedByMessageId,
                 ProcessType.MoveIn.Confirm.DocumentType,
+                DocumentNameCode.ConfirmationOfStartOfSupply.Code,
                 ProcessType.MoveIn.Code,
                 transaction.NewEnergySupplierId,
                 _marketActivityRecordParser.From(marketActivityRecord),
@@ -149,6 +150,7 @@ namespace Messaging.Application.Transactions.MoveIn
             return CreateOutgoingMessage(
                 transaction.StartedByMessageId,
                 ProcessType.MoveIn.Reject.DocumentType,
+                DocumentNameCode.ConfirmationOfStartOfSupply.Code,
                 ProcessType.MoveIn.Code,
                 transaction.NewEnergySupplierId,
                 _marketActivityRecordParser.From(marketActivityRecord),
@@ -160,10 +162,18 @@ namespace Messaging.Application.Transactions.MoveIn
             return _validationErrorTranslator.TranslateAsync(validationErrors);
         }
 
-        private OutgoingMessage CreateOutgoingMessage(string id, string documentType, string processType, string receiverId, string marketActivityRecordPayload, string reasonCode)
+        private OutgoingMessage CreateOutgoingMessage(
+            string id,
+            string documentType,
+            string type,
+            string processType,
+            string receiverId,
+            string marketActivityRecordPayload,
+            string reasonCode)
         {
             return new OutgoingMessage(
                 documentType,
+                type,
                 receiverId,
                 _correlationContext.Id,
                 id,

--- a/source/Messaging.Application/Xml/SchemaStore/Schemas/urn-ediel-org-structure-confirmrequestchangeofsupplier-0-1.xsd
+++ b/source/Messaging.Application/Xml/SchemaStore/Schemas/urn-ediel-org-structure-confirmrequestchangeofsupplier-0-1.xsd
@@ -32,7 +32,7 @@
 	<xs:complexType name="ConfirmRequestChangeOfSupplier_MarketDocument" sawsdl:modelReference="http://iec.ch/TC57/CIM101#MarketDocument">
 		<xs:sequence>
 			<xs:element name="mRID" type="xs:string" minOccurs="1" maxOccurs="1" sawsdl:modelReference="http://iec.ch/TC57/CIM101#IdentifiedObject.mRID"/>
-			<xs:element name="type" type="cim:MessageKind_String" default="E44" minOccurs="1" maxOccurs="1" sawsdl:modelReference="http://iec.ch/TC57/CIM101#Document.type"/>
+			<xs:element name="type" type="cim:MessageKind_String" default="414" minOccurs="1" maxOccurs="1" sawsdl:modelReference="http://iec.ch/TC57/CIM101#Document.type"/>
 			<xs:element name="process.processType" type="cim:ProcessKind_String" minOccurs="1" maxOccurs="1" sawsdl:modelReference="http://iec.ch/TC57/CIM101#Process.processType"/>
 			<xs:element name="businessSector.type" type="cim:BusinessSectorKind_String" minOccurs="0" maxOccurs="1" sawsdl:modelReference="http://iec.ch/TC57/CIM101#BusinessSector.type"/>
 			<xs:element name="sender_MarketParticipant.mRID" type="cim:PartyID_String" minOccurs="1" maxOccurs="1" sawsdl:modelReference="http://iec.ch/TC57/CIM101#IdentifiedObject.mRID"/>

--- a/source/Messaging.Application/Xml/SchemaStore/Schemas/urn-ediel-org-structure-rejectrequestchangeofsupplier-0-1.xsd
+++ b/source/Messaging.Application/Xml/SchemaStore/Schemas/urn-ediel-org-structure-rejectrequestchangeofsupplier-0-1.xsd
@@ -59,7 +59,7 @@
 	<xs:complexType name="RejectRequestChangeOfSupplier_MarketDocument" sawsdl:modelReference="http://iec.ch/TC57/CIM101#MarketDocument">
 		<xs:sequence>
 			<xs:element name="mRID" type="xs:string" minOccurs="1" maxOccurs="1" sawsdl:modelReference="http://iec.ch/TC57/CIM101#IdentifiedObject.mRID"/>
-			<xs:element name="type" type="cim:MessageKind_String" default="E44" minOccurs="1" maxOccurs="1" sawsdl:modelReference="http://iec.ch/TC57/CIM101#Document.type"/>
+			<xs:element name="type" type="cim:MessageKind_String" default="414" minOccurs="1" maxOccurs="1" sawsdl:modelReference="http://iec.ch/TC57/CIM101#Document.type"/>
 			<xs:element name="process.processType" type="cim:ProcessKind_String" minOccurs="1" maxOccurs="1" sawsdl:modelReference="http://iec.ch/TC57/CIM101#Process.processType"/>
 			<xs:element name="businessSector.type" type="cim:BusinessSectorKind_String" minOccurs="0" maxOccurs="1" sawsdl:modelReference="http://iec.ch/TC57/CIM101#BusinessSector.type"/>
 			<xs:element name="sender_MarketParticipant.mRID" type="cim:PartyID_String" minOccurs="1" maxOccurs="1" sawsdl:modelReference="http://iec.ch/TC57/CIM101#IdentifiedObject.mRID"/>

--- a/source/Messaging.Application/Xml/SchemaStore/Schemas/urn-entsoe-eu-wgedi-codelists.xsd
+++ b/source/Messaging.Application/Xml/SchemaStore/Schemas/urn-entsoe-eu-wgedi-codelists.xsd
@@ -1424,7 +1424,7 @@
           <xsd:documentation>
             <CodeDescription>
               <Title>Net Production / Consumption</Title>
-              <Definition>Net production/consumption - where signed values will be used.
+              <Definition>Net production/consumption - where signed values will be used. 
 With the following rules: In area=Out area, In party=Out party, + means production and - means consumption.</Definition>
             </CodeDescription>
           </xsd:documentation>
@@ -1635,7 +1635,7 @@ With the following rules: In area=Out area, In party=Out party, + means producti
           <xsd:documentation>
             <CodeDescription>
               <Title>Control Area Program</Title>
-              <Definition>A time series providing the total exchanges between two TSOs (including the commercial transactions, the compensation program and the losses compensation program).
+              <Definition>A time series providing the total exchanges between two TSOs (including the commercial transactions, the compensation program and the losses compensation program). 
 Note this definition might change when UCTE brings forward its coding requirements.</Definition>
             </CodeDescription>
           </xsd:documentation>
@@ -2707,8 +2707,8 @@ Note this definition might change when UCTE brings forward its coding requiremen
             <CodeDescription>
               <Title>Constraint situation</Title>
               <Definition>The timeseries describes the constraint situation for a given TimeInterval.
-A constraint situation can be:
-- composed of a list of network elements in outage associated for each outage to a list of network elements on which remedial actions have been carried out accordingly to contingency process
+A constraint situation can be: 
+- composed of a list of network elements in outage associated for each outage to a list of network elements on which remedial actions have been carried out accordingly to contingency process 
 - or it can be an external constraint.</Definition>
             </CodeDescription>
           </xsd:documentation>
@@ -2719,7 +2719,7 @@ A constraint situation can be:
           <xsd:documentation>
             <CodeDescription>
               <Title>Initial domain</Title>
-              <Definition>The timeseries describe the full flow based domain for a given TimeInterval.
+              <Definition>The timeseries describe the full flow based domain for a given TimeInterval. 
 Critical network elements are displayed in details and their impact on the market is quantified.</Definition>
             </CodeDescription>
           </xsd:documentation>
@@ -2730,7 +2730,7 @@ Critical network elements are displayed in details and their impact on the marke
           <xsd:documentation>
             <CodeDescription>
               <Title>Flow based domain adjusted to long term schedules</Title>
-              <Definition>The timeseries describe the full flow based domain for a given TimeInterval adjusted to the latest update of the schedules.
+              <Definition>The timeseries describe the full flow based domain for a given TimeInterval adjusted to the latest update of the schedules. 
 Critical network elements are displayed in details and their impact on the market is quantified.</Definition>
             </CodeDescription>
           </xsd:documentation>
@@ -4808,7 +4808,7 @@ Critical network elements are displayed in details and their impact on the marke
     <xsd:annotation>
       <xsd:documentation>
         <Uid>ET0010</Uid>
-        <Definition>The contract type defines the conditions under which the capacity is allocated and handled, e.g. daily auction, weekly auction, monthly auction, yearly auction, etc.
+        <Definition>The contract type defines the conditions under which the capacity is allocated and handled, e.g. daily auction, weekly auction, monthly auction, yearly auction, etc. 
 The significance of this type is dependent on area specific coded working methods.</Definition>
       </xsd:documentation>
     </xsd:annotation>
@@ -5421,7 +5421,7 @@ The significance of this type is dependent on area specific coded working method
     <xsd:annotation>
       <xsd:documentation>
         <Uid>ET0003</Uid>
-        <Definition>The DocumentTypeList is only used in XML instances using deprecated ENTSO-E schema; otherwise for XML instances based CIM, the codelist is MessageTypeList.
+        <Definition>The DocumentTypeList is only used in XML instances using deprecated ENTSO-E schema; otherwise for XML instances based CIM, the codelist is MessageTypeList. 
 Therefore, you are kindly advised to refer to the MessageType enumeration, which includes the same enumeration codes.</Definition>
       </xsd:documentation>
     </xsd:annotation>
@@ -7422,7 +7422,7 @@ This enumeration is used in the XML instances based on IEC 62325.</Definition>
           </xsd:documentation>
         </xsd:annotation>
       </xsd:enumeration>
-      <xsd:enumeration value="E44">
+      <xsd:enumeration value="414">
         <xsd:annotation>
           <xsd:documentation>
             <CodeDescription>
@@ -12025,8 +12025,8 @@ This enumeration is used in the XML instances based on IEC 62325.</Definition>
           <xsd:documentation>
             <CodeDescription>
               <Title>Counterpart time series missing </Title>
-              <Definition>This provides an indication that the time series has not got a counterpart time series.
-In the case of an Intermediate Confirmation Report this is advising the recipient that the time series may be rejected at nomination closure if the counterpart time series is not received.
+              <Definition>This provides an indication that the time series has not got a counterpart time series. 
+In the case of an Intermediate Confirmation Report this is advising the recipient that the time series may be rejected at nomination closure if the counterpart time series is not received. 
 In the case of a Final Confirmation Report this is informing the recipient that the time series has been rejected because the counterpart time series has not been forthcoming. </Definition>
             </CodeDescription>
           </xsd:documentation>
@@ -14774,7 +14774,7 @@ In the case of a Final Confirmation Report this is informing the recipient that 
           <xsd:documentation>
             <CodeDescription>
               <Title>Market information aggregator</Title>
-              <Definition>Refer to role model definitions in the ENTSO-E Harmonised Role Model Document.
+              <Definition>Refer to role model definitions in the ENTSO-E Harmonised Role Model Document. 
 A party that collects information from different sources and assembles  it to provide a summary of the market.</Definition>
             </CodeDescription>
           </xsd:documentation>
@@ -14785,7 +14785,7 @@ A party that collects information from different sources and assembles  it to pr
           <xsd:documentation>
             <CodeDescription>
               <Title>Information receiver</Title>
-              <Definition>Refer to role model definitions in the ENTSO-E Harmonised Role Model Document.
+              <Definition>Refer to role model definitions in the ENTSO-E Harmonised Role Model Document. 
 A party, not necessarily a market participant, which receives information about the market.</Definition>
             </CodeDescription>
           </xsd:documentation>
@@ -14796,7 +14796,7 @@ A party, not necessarily a market participant, which receives information about 
           <xsd:documentation>
             <CodeDescription>
               <Title>Reserve Allocator</Title>
-              <Definition>Refer to role model definitions in the ENTSO-E Harmonised Role Model Document.
+              <Definition>Refer to role model definitions in the ENTSO-E Harmonised Role Model Document. 
 A party that informs the market of reserve requirements, receives tenders against the requirements and in compliance with the prequalification criteria, determines what tenders meet requirements and assigns tenders.</Definition>
             </CodeDescription>
           </xsd:documentation>
@@ -14807,7 +14807,7 @@ A party that informs the market of reserve requirements, receives tenders agains
           <xsd:documentation>
             <CodeDescription>
               <Title>MOL Responsible</Title>
-              <Definition>Refer to role model definitions in the ENTSO-E Harmonised Role Model Document.
+              <Definition>Refer to role model definitions in the ENTSO-E Harmonised Role Model Document. 
 A party that Informs the market of reserve requirements, receives tenders against the requirements and in compliance with the prequalification criteria, determines what tenders meet requirements and assigns tenders.</Definition>
             </CodeDescription>
           </xsd:documentation>
@@ -14818,7 +14818,7 @@ A party that Informs the market of reserve requirements, receives tenders agains
           <xsd:documentation>
             <CodeDescription>
               <Title>Capacity Coordinator</Title>
-              <Definition>Refer to role model definitions in the ENTSO-E Harmonised Role Model Document.
+              <Definition>Refer to role model definitions in the ENTSO-E Harmonised Role Model Document. 
 A party, acting on behalf of the SOs involved, responsible for establishing a coordinated Offered Capacity and/or NTC and/or ATC between several Market Balance Areas.</Definition>
             </CodeDescription>
           </xsd:documentation>
@@ -14829,7 +14829,7 @@ A party, acting on behalf of the SOs involved, responsible for establishing a co
           <xsd:documentation>
             <CodeDescription>
               <Title>Reconciliation Accountable</Title>
-              <Definition>Refer to role model definitions in the ENTSO-E Harmonised Role Model Document.
+              <Definition>Refer to role model definitions in the ENTSO-E Harmonised Role Model Document. 
 A party that is financially accountable for the reconciled volume of energy products for a profiled local metering point.</Definition>
             </CodeDescription>
           </xsd:documentation>

--- a/source/Messaging.IntegrationTests/Application/Transactions/MoveIn/RequestMoveInTests.cs
+++ b/source/Messaging.IntegrationTests/Application/Transactions/MoveIn/RequestMoveInTests.cs
@@ -115,7 +115,7 @@ namespace Messaging.IntegrationTests.Application.Transactions.MoveIn
         private static void AssertHeader(XDocument document, OutgoingMessage message, string expectedReasonCode)
         {
             Assert.NotEmpty(AssertXmlMessage.GetMessageHeaderValue(document, "mRID")!);
-            AssertXmlMessage.AssertHasHeaderValue(document, "type", "E44");
+            AssertXmlMessage.AssertHasHeaderValue(document, "type", "414");
             AssertXmlMessage.AssertHasHeaderValue(document, "process.processType", message.ProcessType);
             AssertXmlMessage.AssertHasHeaderValue(document, "businessSector.type", "23");
             AssertXmlMessage.AssertHasHeaderValue(document, "sender_MarketParticipant.mRID", message.SenderId);

--- a/source/Messaging.IntegrationTests/Infrastructure/OutgoingMessages/MessageAvailabilityPublisherTests.cs
+++ b/source/Messaging.IntegrationTests/Infrastructure/OutgoingMessages/MessageAvailabilityPublisherTests.cs
@@ -67,6 +67,7 @@ namespace Messaging.IntegrationTests.Infrastructure.OutgoingMessages
             var transaction = new IncomingMessageBuilder().Build();
             return new OutgoingMessage(
                 "FakeDocumentType",
+                DocumentNameCode.ConfirmationOfStartOfSupply.Code,
                 transaction.Message.ReceiverId,
                 _correlationContext.Id,
                 transaction.MarketActivityRecord.Id,

--- a/source/Messaging.Tests/OutgoingMessages/AccountingPointCharacteristics/AccountingPointCharacteristicsDocumentWriterTests.cs
+++ b/source/Messaging.Tests/OutgoingMessages/AccountingPointCharacteristics/AccountingPointCharacteristicsDocumentWriterTests.cs
@@ -51,12 +51,9 @@ public class AccountingPointCharacteristicsDocumentWriterTests
     [Fact]
     public async Task Document_is_valid()
     {
-        var header = new MessageHeader("E03", "SenderId", "DDZ", "ReceiverId", "DDQ", Guid.NewGuid().ToString(), _systemDateTimeProvider.Now(), null);
+        var header = new MessageHeader("E03", "E45", "SenderId", "DDZ", "ReceiverId", "DDQ", Guid.NewGuid().ToString(), _systemDateTimeProvider.Now(), null);
         var marketActivityRecord = _sampleData.CreateMarketActivityRecord();
-        var marketActivityRecords = new List<MarketActivityRecord>()
-        {
-            marketActivityRecord,
-        };
+        var marketActivityRecords = new List<MarketActivityRecord>() { marketActivityRecord, };
         var message = await _documentWriter.WriteAsync(header, marketActivityRecords.Select(record => _marketActivityRecordParser.From(record)).ToList()).ConfigureAwait(false);
         await AssertMessage(message, header, marketActivityRecords).ConfigureAwait(false);
     }

--- a/source/Messaging.Tests/OutgoingMessages/AssertXmlMessage.cs
+++ b/source/Messaging.Tests/OutgoingMessages/AssertXmlMessage.cs
@@ -65,7 +65,7 @@ namespace Messaging.Tests.OutgoingMessages
         internal static void AssertHeader(MessageHeader header, XDocument document)
         {
             Assert.NotEmpty(AssertXmlMessage.GetMessageHeaderValue(document, "mRID")!);
-            AssertHasHeaderValue(document, "type", "E44");
+            AssertHasHeaderValue(document, "type", "414");
             AssertHasHeaderValue(document, "process.processType", header.ProcessType);
             AssertHasHeaderValue(document, "businessSector.type", "23");
             AssertHasHeaderValue(document, "sender_MarketParticipant.mRID", header.SenderId);

--- a/source/Messaging.Tests/OutgoingMessages/ConfirmRequestChangeOfSupplier/ConfirmRequestChangeOfSupplierDocumentWriterTests.cs
+++ b/source/Messaging.Tests/OutgoingMessages/ConfirmRequestChangeOfSupplier/ConfirmRequestChangeOfSupplierDocumentWriterTests.cs
@@ -49,11 +49,10 @@ namespace Messaging.Tests.OutgoingMessages.ConfirmRequestChangeOfSupplier
         [Fact]
         public async Task Document_is_valid()
         {
-            var header = new MessageHeader("E03", "SenderId", "DDZ", "ReceiverId", "DDQ", Guid.NewGuid().ToString(), _systemDateTimeProvider.Now(), "A01");
+            var header = new MessageHeader("E03", "414", "SenderId", "DDZ", "ReceiverId", "DDQ", Guid.NewGuid().ToString(), _systemDateTimeProvider.Now(), "A01");
             var marketActivityRecords = new List<MarketActivityRecord>()
             {
-                new(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "FakeMarketEvaluationPointId"),
-                new(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "FakeMarketEvaluationPointId"),
+                new(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "FakeMarketEvaluationPointId"), new(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "FakeMarketEvaluationPointId"),
             };
 
             var message = await _documentWriter.WriteAsync(header, marketActivityRecords.Select(record => _marketActivityRecordParser.From(record)).ToList()).ConfigureAwait(false);

--- a/source/Messaging.Tests/OutgoingMessages/GenericNotificationDocumentWriterTests.cs
+++ b/source/Messaging.Tests/OutgoingMessages/GenericNotificationDocumentWriterTests.cs
@@ -48,7 +48,7 @@ namespace Messaging.Tests.OutgoingMessages
         [Fact]
         public async Task Document_is_valid()
         {
-            var header = new MessageHeader("E03", "SenderId", "DDZ", "ReceiverId", "DDQ", Guid.NewGuid().ToString(), _systemDateTimeProvider.Now());
+            var header = new MessageHeader("E03", "E44", "SenderId", "DDZ", "ReceiverId", "DDQ", Guid.NewGuid().ToString(), _systemDateTimeProvider.Now());
             var marketActivityRecords = new List<MarketActivityRecord>()
             {
                 new(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "FakeMarketEvaluationPointId", _systemDateTimeProvider.Now()),

--- a/source/Messaging.Tests/OutgoingMessages/RejectRequestChangeOfSupplier/RejectRequestChangeOfSupplierDocumentWriterTests.cs
+++ b/source/Messaging.Tests/OutgoingMessages/RejectRequestChangeOfSupplier/RejectRequestChangeOfSupplierDocumentWriterTests.cs
@@ -48,20 +48,12 @@ public class RejectRequestChangeOfSupplierDocumentWriterTests
     [Fact]
     public async Task Document_is_valid()
     {
-        var header = new MessageHeader("E03", "SenderId", "DDZ", "ReceiverId", "DDQ", Guid.NewGuid().ToString(), _systemDateTimeProvider.Now(), "A01");
+        var header = new MessageHeader("E03", "414", "SenderId", "DDZ", "ReceiverId", "DDQ", Guid.NewGuid().ToString(), _systemDateTimeProvider.Now(), "A01");
         var marketActivityRecords = new List<MarketActivityRecord>()
         {
-            new(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "FakeMarketEvaluationPointId", new List<Reason>()
-            {
-                new Reason("Reason1", "999"),
-                new Reason("Reason2", "999"),
-            }),
+            new(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "FakeMarketEvaluationPointId", new List<Reason>() { new Reason("Reason1", "999"), new Reason("Reason2", "999"), }),
             new(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "FakeMarketEvaluationPointId",
-            new List<Reason>()
-            {
-                new Reason("Reason3", "999"),
-                new Reason("Reason4", "999"),
-            }),
+                new List<Reason>() { new Reason("Reason3", "999"), new Reason("Reason4", "999"), }),
         };
 
         var message = await _documentWriter.WriteAsync(header, marketActivityRecords.Select(record => _marketActivityRecordParser.From(record)).ToList()).ConfigureAwait(false);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description

Implemented DocumentNameCode to be used as Type in move in requests and generic notification.

The original task for this had requested to change all cim type 414 to E44 - Jan followed up on this and it turns out that it should only be the case for generic notification.
This PR adds a type to the MessageHeader that holds the respective code for each message so that they may differ depending on what type of message has been created.

TODO: Please verify if this needs anything else to work.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1126 
