### PR TITLE
Remove DOTNET_VERSION

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@7.6.0
 
   dotnet_solution_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@temporarily_disable_integration_test # TODO: Revert to next version when integration test issue is solved
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.7.0 # TODO: Revert to next version when integration test issue is solved
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MarketRoles.sln'      
       USE_SQLLOCALDB_2019: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,7 @@ jobs:
   dotnet_solution_ci:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@temporarily_disable_integration_test # TODO: Revert to next version when integration test issue is solved
     with:
-      SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MarketRoles.sln'
-      DOTNET_VERSION: '6.0.301'
+      SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MarketRoles.sln'      
       USE_SQLLOCALDB_2019: true
       PREPARE_OUTPUTS: true
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@7.6.0
 
   dotnet_solution_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.7.0 # TODO: Revert to next version when integration test issue is solved
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.7.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MarketRoles.sln'      
       USE_SQLLOCALDB_2019: true

--- a/.github/workflows/integration-events-publish.yml
+++ b/.github/workflows/integration-events-publish.yml
@@ -42,7 +42,7 @@ env:
 
 jobs:
   build_and_publish:
-    runs-on: windows-2022
+    runs-on: windows-latest
     name: Publish bundle to NuGet.org
 
     permissions:
@@ -50,21 +50,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.7.0
 
       - name: Setup dotnet and tools
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.5.0
-        with:
-          DOTNET_VERSION: '6.0.300'
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.7.0
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.7.0
         with:
           SOLUTION_FILE_PATH: './source/IntegrationEvents/IntegrationEvents.sln'
           USE_CODE_COVERAGE: 'false'
 
       - name: Pack IntegrationEvents project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/IntegrationEvents/source/IntegrationEvents/IntegrationEvents.csproj'
 
@@ -77,7 +75,7 @@ jobs:
             .github/workflows/integration-events.yml
 
       - name: Assert versions of NuGet packages and push them to NuGet.org
-        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.7.0
         with:
           PUSH_PACKAGES: ${{ env.PUSH_PACKAGES }}
           CONTENT_CHANGED: ${{ steps.changed-content.outputs.any_changed }}


### PR DESCRIPTION
Speed up CI execution time by using default .NET Core SDK version pre-installed on hosted Github Runner

Ref: https://github.com/Energinet-DataHub/the-outlaws/issues/360