### PR TITLE
Throw error when transaction or messageid is empty

### DIFF
--- a/source/Messaging.CimMessageAdapter/Errors/EmptyMessageId.cs
+++ b/source/Messaging.CimMessageAdapter/Errors/EmptyMessageId.cs
@@ -1,0 +1,11 @@
+﻿using JetBrains.Annotations;
+
+namespace Messaging.CimMessageAdapter.Errors;
+
+public class EmptyMessageId : ValidationError
+{
+    public EmptyMessageId()
+        : base($"Message id cannot be empty", "B2B-003")
+    {
+    }
+}

--- a/source/Messaging.CimMessageAdapter/Errors/EmptyMessageId.cs
+++ b/source/Messaging.CimMessageAdapter/Errors/EmptyMessageId.cs
@@ -1,4 +1,16 @@
-﻿using JetBrains.Annotations;
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Messaging.CimMessageAdapter.Errors;
 

--- a/source/Messaging.CimMessageAdapter/Errors/EmptyTransactionId.cs
+++ b/source/Messaging.CimMessageAdapter/Errors/EmptyTransactionId.cs
@@ -1,10 +1,22 @@
-﻿using JetBrains.Annotations;
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Messaging.CimMessageAdapter.Errors;
 
 public class EmptyTransactionId : ValidationError
 {
-    public EmptyTransactionId([NotNull] string message)
+    public EmptyTransactionId(string message)
         : base($"Transaction id may not be empty", "B2B-005")
     {
     }

--- a/source/Messaging.CimMessageAdapter/Errors/EmptyTransactionId.cs
+++ b/source/Messaging.CimMessageAdapter/Errors/EmptyTransactionId.cs
@@ -1,0 +1,11 @@
+﻿using JetBrains.Annotations;
+
+namespace Messaging.CimMessageAdapter.Errors;
+
+public class EmptyTransactionId : ValidationError
+{
+    public EmptyTransactionId([NotNull] string message)
+        : base($"Transaction id may not be empty", "B2B-005")
+    {
+    }
+}

--- a/source/Messaging.CimMessageAdapter/MessageReceiver.cs
+++ b/source/Messaging.CimMessageAdapter/MessageReceiver.cs
@@ -62,6 +62,7 @@ namespace Messaging.CimMessageAdapter
 
             await AuthorizeSenderAsync(messageHeader!).ConfigureAwait(false);
             await VerifyReceiverAsync(messageHeader!).ConfigureAwait(false);
+            EnsureMessageId(messageHeader!.MessageId);
             await CheckMessageIdAsync(messageHeader!.MessageId).ConfigureAwait(false);
             if (_errors.Count > 0)
             {
@@ -70,6 +71,11 @@ namespace Messaging.CimMessageAdapter
 
             foreach (var marketActivityRecord in messageParserResult.MarketActivityRecords)
             {
+                if (string.IsNullOrEmpty(marketActivityRecord.Id))
+                {
+                    return Result.Failure(new EmptyTransactionId(marketActivityRecord.Id));
+                }
+
                 if (await CheckTransactionIdAsync(marketActivityRecord.Id).ConfigureAwait(false) == false)
                 {
                     return Result.Failure(new DuplicateTransactionIdDetected(marketActivityRecord.Id));
@@ -101,6 +107,15 @@ namespace Messaging.CimMessageAdapter
         private Task AddToTransactionQueueAsync(IncomingMessage transaction)
         {
             return _messageQueueDispatcher.AddAsync(transaction);
+        }
+
+        private void EnsureMessageId(string messageId)
+        {
+            if (messageId == null) throw new ArgumentNullException(nameof(messageId));
+            if (string.IsNullOrEmpty(messageId))
+            {
+                _errors.Add(new EmptyMessageId());
+            }
         }
 
         private async Task CheckMessageIdAsync(string messageId)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description

Added error for when messageid or transactionid is empty. 

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
