### PR TITLE
Ensure internal command constructors are decorated with JSON attribute

### DIFF
--- a/source/Messaging.Application/MasterData/MarketEvaluationPoints/SetEnergySupplier.cs
+++ b/source/Messaging.Application/MasterData/MarketEvaluationPoints/SetEnergySupplier.cs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Text.Json.Serialization;
 using Messaging.Application.Common.Commands;
 
 namespace Messaging.Application.MasterData.MarketEvaluationPoints;
 
 public class SetEnergySupplier : InternalCommand
 {
+    [JsonConstructor]
     public SetEnergySupplier(string marketEvaluationPointNumber, string energySupplierNumber)
     {
         MarketEvaluationPointNumber = marketEvaluationPointNumber;

--- a/source/Messaging.Application/Transactions/MoveIn/CompleteMoveInTransaction.cs
+++ b/source/Messaging.Application/Transactions/MoveIn/CompleteMoveInTransaction.cs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Text.Json.Serialization;
 using Messaging.Application.Common.Commands;
 
 namespace Messaging.Application.Transactions.MoveIn;
 
 public class CompleteMoveInTransaction : InternalCommand
 {
+    [JsonConstructor]
     public CompleteMoveInTransaction(string processId)
     {
         ProcessId = processId;

--- a/source/Messaging.Application/Transactions/MoveIn/FetchMeteringPointMasterData.cs
+++ b/source/Messaging.Application/Transactions/MoveIn/FetchMeteringPointMasterData.cs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Text.Json.Serialization;
 using Messaging.Application.Common.Commands;
 
 namespace Messaging.Application.Transactions.MoveIn;
 
 public class FetchMeteringPointMasterData : InternalCommand
 {
+    [JsonConstructor]
     public FetchMeteringPointMasterData(string businessProcessId, string marketEvaluationPointNumber, string transactionId)
     {
         BusinessProcessId = businessProcessId;

--- a/source/Messaging.Application/Transactions/MoveIn/ForwardMeteringPointMasterData.cs
+++ b/source/Messaging.Application/Transactions/MoveIn/ForwardMeteringPointMasterData.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Text.Json.Serialization;
 using Messaging.Application.Common.Commands;
 using Messaging.Application.MasterData;
 
@@ -19,6 +20,7 @@ namespace Messaging.Application.Transactions.MoveIn;
 
 public class ForwardMeteringPointMasterData : InternalCommand
 {
+    [JsonConstructor]
     public ForwardMeteringPointMasterData(string transactionId, MasterDataContent masterDataContent)
     {
         TransactionId = transactionId;

--- a/source/Messaging.ArchitectureTests/Application/InternalCommandTests.cs
+++ b/source/Messaging.ArchitectureTests/Application/InternalCommandTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json.Serialization;
+using Messaging.Application.Common.Commands;
+using Messaging.Infrastructure.Configuration;
+using Xunit;
+
+namespace Messaging.ArchitectureTests.Application;
+
+public class InternalCommandTests
+{
+    [Theory(DisplayName = nameof(Has_json_constructor_attribute))]
+    [MemberData(nameof(GetInternalCommands))]
+    public void Has_json_constructor_attribute(Type internalCommand)
+    {
+        if (internalCommand == null) throw new ArgumentNullException(nameof(internalCommand));
+        var jsonConstructorAttributes = internalCommand
+            .GetConstructors()
+            .SelectMany(c => c.GetCustomAttributes()
+                .Where(t => t is JsonConstructorAttribute));
+
+        Assert.True(jsonConstructorAttributes.Any());
+    }
+
+    private static IEnumerable<object[]> GetInternalCommands()
+    {
+        return ApplicationAssemblies.Application
+            .GetTypes()
+            .Where(t => t.IsSubclassOf(typeof(InternalCommand)))
+            .Select(t => new[] { t });
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description
Ensure internal command constructors are decorated with JSON attribute
