### PR TITLE
Changed service bus queue name on CustomerMasterDataResponseListener …

### DIFF
--- a/source/Messaging.Api/MasterDataReceivers/CustomerMasterDataResponseListener.cs
+++ b/source/Messaging.Api/MasterDataReceivers/CustomerMasterDataResponseListener.cs
@@ -41,7 +41,7 @@ public class CustomerMasterDataResponseListener
     }
 
     [Function("CustomerMasterDataResponseListener")]
-    public async Task RunAsync([ServiceBusTrigger("CUSTOMER_DATA_RESPONSE_QUEUE_NAME", Connection = "SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER")] string data, FunctionContext context)
+    public async Task RunAsync([ServiceBusTrigger("%CUSTOMER_MASTER_DATA_RESPONSE_QUEUE_NAME%", Connection = "SERVICE_BUS_CONNECTION_STRING_FOR_INTEGRATION_EVENTS_LISTENER")] string data, FunctionContext context)
     {
         if (data == null) throw new ArgumentNullException(nameof(data));
         if (context == null) throw new ArgumentNullException(nameof(context));


### PR DESCRIPTION
…to match the registered name

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description

Changes the queue name on CustomerMasterDataResponseListener to use the correct environment variable.
