### PR TITLE
Use environment for OIDC login

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       USE_SQLLOCALDB_2019: true
       PREPARE_OUTPUTS: true
       DOTNET_VERSION: '6.0.300'
+      ENVIRONMENT: AzureAuth
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
## Description

Change federated credentials to use "environment" as "subject" when authenticating to Azure in workflows.

## References

https://app.zenhub.com/workspaces/mighty-ducks---the-outlaws-6193fe815d79fc0011e741b1/issues/energinet-datahub/the-outlaws/607
