### PR TITLE
Add authenticator for development and test

### DIFF
--- a/source/Messaging.Api/Program.cs
+++ b/source/Messaging.Api/Program.cs
@@ -110,6 +110,7 @@ namespace Messaging.Api
                         .AddPeekConfiguration(new BundleConfiguration(runtime.MAX_NUMBER_OF_PAYLOADS_IN_BUNDLE))
                         .AddRemoteBusinessService<DummyRequest, DummyReply>("Dummy", "Dummy")
                         .AddBearerAuthentication(tokenValidationParameters)
+                        .AddAuthentication()
                         .AddDatabaseConnectionFactory(databaseConnectionString!)
                         .AddSystemClock(new SystemDateTimeProvider())
                         .AddDatabaseContext(databaseConnectionString!)

--- a/source/Messaging.Api/Program.cs
+++ b/source/Messaging.Api/Program.cs
@@ -24,11 +24,12 @@ using Messaging.Api.Configuration.Middleware.Authentication.MarketActors;
 using Messaging.Api.Configuration.Middleware.Correlation;
 using Messaging.Application.Actors;
 using Messaging.Application.Configuration;
-using Messaging.Application.OutgoingMessages;
 using Messaging.Application.OutgoingMessages.Peek;
 using Messaging.Application.Transactions.MoveIn;
 using Messaging.CimMessageAdapter.Messages.Queues;
+using Messaging.Infrastructure.Actors;
 using Messaging.Infrastructure.Configuration;
+using Messaging.Infrastructure.Configuration.Authentication;
 using Messaging.Infrastructure.Configuration.MessageBus;
 using Messaging.Infrastructure.Configuration.MessageBus.RemoteBusinessServices;
 using Messaging.Infrastructure.OutgoingMessages;
@@ -110,7 +111,17 @@ namespace Messaging.Api
                         .AddPeekConfiguration(new BundleConfiguration(runtime.MAX_NUMBER_OF_PAYLOADS_IN_BUNDLE))
                         .AddRemoteBusinessService<DummyRequest, DummyReply>("Dummy", "Dummy")
                         .AddBearerAuthentication(tokenValidationParameters)
-                        .AddAuthentication()
+                        .AddAuthentication(sp =>
+                        {
+                            if (runtime.IsRunningLocally())
+                            {
+                                return new DevMarketActorAuthenticator(
+                                    sp.GetRequiredService<IActorLookup>(),
+                                    sp.GetRequiredService<IActorRegistry>());
+                            }
+
+                            return new MarketActorAuthenticator(sp.GetRequiredService<IActorLookup>());
+                        })
                         .AddDatabaseConnectionFactory(databaseConnectionString!)
                         .AddSystemClock(new SystemDateTimeProvider())
                         .AddDatabaseContext(databaseConnectionString!)

--- a/source/Messaging.Infrastructure/Configuration/Authentication/DevMarketActorAuthenticator.cs
+++ b/source/Messaging.Infrastructure/Configuration/Authentication/DevMarketActorAuthenticator.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Messaging.Application.Actors;
+using Messaging.Infrastructure.Actors;
+
+namespace Messaging.Infrastructure.Configuration.Authentication;
+
+public class DevMarketActorAuthenticator : MarketActorAuthenticator
+{
+    private readonly IActorRegistry _actorRegistry;
+
+    public DevMarketActorAuthenticator(IActorLookup actorLookup, IActorRegistry actorRegistry)
+        : base(actorLookup)
+    {
+        _actorRegistry = actorRegistry;
+    }
+
+    public override async Task AuthenticateAsync(ClaimsPrincipal claimsPrincipal)
+    {
+        ArgumentNullException.ThrowIfNull(claimsPrincipal);
+
+        var actorNumberClaim = claimsPrincipal.FindFirst(claim => claim.Type.Equals("test-actornumber", StringComparison.OrdinalIgnoreCase));
+        var userIdClaim = claimsPrincipal.FindFirst(claim => claim.Type.Equals(ClaimsMap.UserId, StringComparison.OrdinalIgnoreCase));
+        if (actorNumberClaim is not null && userIdClaim is not null)
+        {
+            await _actorRegistry.TryStoreAsync(
+                new CreateActor(
+                    Guid.NewGuid().ToString(),
+                    userIdClaim.Value,
+                    actorNumberClaim.Value)).ConfigureAwait(false);
+        }
+
+        await base.AuthenticateAsync(claimsPrincipal).ConfigureAwait(false);
+    }
+}

--- a/source/Messaging.Infrastructure/Configuration/Authentication/MarketActorAuthenticator.cs
+++ b/source/Messaging.Infrastructure/Configuration/Authentication/MarketActorAuthenticator.cs
@@ -34,7 +34,7 @@ namespace Messaging.Infrastructure.Configuration.Authentication
 
         public MarketActorIdentity CurrentIdentity { get; private set; } = new NotAuthenticated();
 
-        public async Task AuthenticateAsync(ClaimsPrincipal claimsPrincipal)
+        public virtual async Task AuthenticateAsync(ClaimsPrincipal claimsPrincipal)
         {
             if (claimsPrincipal == null) throw new ArgumentNullException(nameof(claimsPrincipal));
 

--- a/source/Messaging.Infrastructure/Configuration/CompositionRoot.cs
+++ b/source/Messaging.Infrastructure/Configuration/CompositionRoot.cs
@@ -85,7 +85,6 @@ namespace Messaging.Infrastructure.Configuration
             services.AddScoped<IMessageIds, MessageIdRegistry>();
             services.AddScoped(typeof(IMessageQueueDispatcher<>), typeof(MessageQueueDispatcher<>));
             services.AddScoped<IMoveInTransactionRepository, MoveInTransactionRepository>();
-            services.AddScoped<IMarketActorAuthenticator, MarketActorAuthenticator>();
             services.AddScoped<IUnitOfWork, UnitOfWork>();
             services.AddScoped<IOutgoingMessageStore, OutgoingMessageStore>();
             services.AddScoped<IMessageRequestNotifications, MessageRequestNotifications>();
@@ -135,6 +134,20 @@ namespace Messaging.Infrastructure.Configuration
         {
             _services.AddScoped<CurrentClaimsPrincipal>();
             _services.AddScoped(sp => new JwtTokenParser(tokenValidationParameters));
+            return this;
+        }
+
+        public CompositionRoot AddAuthentication(Func<IServiceProvider, IMarketActorAuthenticator>? authenticatorBuilder = null)
+        {
+            if (authenticatorBuilder is null)
+            {
+                _services.AddScoped<IMarketActorAuthenticator, MarketActorAuthenticator>();
+            }
+            else
+            {
+                _services.AddScoped(authenticatorBuilder);
+            }
+
             return this;
         }
 

--- a/source/Messaging.IntegrationTests/TestBase.cs
+++ b/source/Messaging.IntegrationTests/TestBase.cs
@@ -58,6 +58,7 @@ namespace Messaging.IntegrationTests
             _services.AddSingleton(
                 _ => new ServiceBusClient(CreateFakeServiceBusConnectionString()));
             CompositionRoot.Initialize(_services)
+                .AddAuthentication()
                 .AddPeekConfiguration(new BundleConfigurationStub())
                 .AddRemoteBusinessService<DummyRequest, DummyReply>(sp => new RemoteBusinessServiceRequestSenderSpy<DummyRequest>("Dummy"), "Dummy")
                 .AddDatabaseConnectionFactory(DatabaseFixture.ConnectionString)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description
This PR adds a test/dev version of `MarketActorAuthenticator`. This authenticator will automatically create the actor in the system, based on magic values provided in the test JWT. The following claims are required in order to automatically add a test actor to the  system:

azp: <A guid>
test-actornumber: <a GLN or EIC number>