### PR TITLE
Added PERFORMANCE_TEST_ENABLED environment variable.

### DIFF
--- a/source/Messaging.Api/Program.cs
+++ b/source/Messaging.Api/Program.cs
@@ -96,7 +96,7 @@ namespace Messaging.Api
                         .AddBearerAuthentication(tokenValidationParameters)
                         .AddAuthentication(sp =>
                         {
-                            if (runtime.IsRunningLocally())
+                            if (runtime.IsRunningLocally() || string.Equals(runtime.PERFORMANCE_TEST_ENABLED, "true", StringComparison.OrdinalIgnoreCase))
                             {
                                 return new DevMarketActorAuthenticator(
                                     sp.GetRequiredService<IActorLookup>(),

--- a/source/Messaging.Api/RuntimeEnvironment.cs
+++ b/source/Messaging.Api/RuntimeEnvironment.cs
@@ -45,6 +45,9 @@ namespace Messaging.Api
         public string? INTEGRATION_EVENT_TOPIC_NAME =>
             GetEnvironmentVariable(nameof(INTEGRATION_EVENT_TOPIC_NAME));
 
+        public virtual string? PERFORMANCE_TEST_ENABLED =>
+            GetEnvironmentVariable(nameof(PERFORMANCE_TEST_ENABLED));
+
         public string? MARKET_PARTICIPANT_CHANGED_ACTOR_CREATED_SUBSCRIPTION_NAME =>
             GetEnvironmentVariable(nameof(MARKET_PARTICIPANT_CHANGED_ACTOR_CREATED_SUBSCRIPTION_NAME));
 


### PR DESCRIPTION
## Description
Added PERFORMANCE_TEST_ENABLED environment variable.
This is used inMessaging.Api for controlling which MarketActorAuthenticator implementation to use during test
