### PR TITLE
Performance Test: http/https protocol configuration

### DIFF
--- a/source/Messaging.PerformanceTest/MoveIn/MoveInService.cs
+++ b/source/Messaging.PerformanceTest/MoveIn/MoveInService.cs
@@ -44,7 +44,12 @@ internal class MoveInService : IMoveInService
 
         using var httpClient = new HttpClient();
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", jwt);
-        await httpClient.PostAsync(new Uri($"http://{_hostname}:{_hostport}/api/RequestChangeOfSupplier"), body).ConfigureAwait(false);
+        await httpClient.PostAsync(new Uri($"{GetHttpProtocol(_hostport)}://{_hostname}:{_hostport}/api/RequestChangeOfSupplier"), body).ConfigureAwait(false);
+    }
+
+    private static string GetHttpProtocol(string httpPort)
+    {
+        return httpPort.Equals("443", StringComparison.Ordinal) ? "https" : "http";
     }
 
     private static string GetMoveInPayload(string uniqueActorNumber)

--- a/source/Messaging.PerformanceTest/Program.cs
+++ b/source/Messaging.PerformanceTest/Program.cs
@@ -39,8 +39,6 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-app.UseHttpsRedirection();
-
 app.UseAuthorization();
 
 app.MapControllers();


### PR DESCRIPTION
## Description
Allow use of both http and https protocol on the test-utility application service. It is allowed 
temporarily due to an certificate issue when switching from k6 to JMeter.

When calling the Messaging.Api from the PerformanceTest service determine by port number if the http/https protocol should be used.