### PR TITLE
Perform the MessageCount using a Query instead of a Command

### DIFF
--- a/source/Messaging.Api/OutgoingMessages/MessageCountRequestListener.cs
+++ b/source/Messaging.Api/OutgoingMessages/MessageCountRequestListener.cs
@@ -48,11 +48,11 @@ public class MessageCountRequestListener
         FunctionContext executionContext)
     {
         var result = await _mediator.Send(
-                new MessageCountRequest(_marketActorAuthenticator.CurrentIdentity.Number))
+                new MessageCountQuery(_marketActorAuthenticator.CurrentIdentity.Number))
             .ConfigureAwait(false);
 
         var response = HttpResponseData.CreateResponse(request);
-        response.Body = new MemoryStream(Encoding.UTF8.GetBytes(result.MessageCount.ToString(CultureInfo.InvariantCulture)));
+        response.Body = new MemoryStream(Encoding.UTF8.GetBytes(result.Data!.MessageCount.ToString(CultureInfo.InvariantCulture)));
         response.Headers.Add("content-type", "application/xml");
         response.StatusCode = HttpStatusCode.OK;
         return response;

--- a/source/Messaging.Application/Configuration/Queries/IQuery.cs
+++ b/source/Messaging.Application/Configuration/Queries/IQuery.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using MediatR;
+
+namespace Messaging.Application.Configuration.Queries;
+
+/// <summary>
+/// Data query
+/// </summary>
+#pragma warning disable CA1040 // This marker interface is needed in order to distinguish between commands and queries
+public interface IQuery<out TResult> : IRequest<TResult>
+{
+}
+#pragma warning restore

--- a/source/Messaging.Application/Configuration/Queries/QueryResult.cs
+++ b/source/Messaging.Application/Configuration/Queries/QueryResult.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Messaging.Application.Configuration.Queries;
+
+public class QueryResult<TData>
+{
+    public QueryResult(string error)
+    {
+        Error = error;
+    }
+
+    public QueryResult(TData data)
+    {
+        Data = data;
+    }
+
+    public string Error { get; } = string.Empty;
+
+    public TData? Data { get; }
+}

--- a/source/Messaging.Application/OutgoingMessages/MessageCount/MessageCountRequestHandler.cs
+++ b/source/Messaging.Application/OutgoingMessages/MessageCount/MessageCountRequestHandler.cs
@@ -17,11 +17,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Messaging.Application.Configuration.Commands.Commands;
+using Messaging.Application.Configuration.Queries;
 using Messaging.Domain.Actors;
 
 namespace Messaging.Application.OutgoingMessages.MessageCount;
 
-public class MessageCountRequestHandler : IRequestHandler<MessageCountRequest, MessageCountResult>
+public class MessageCountRequestHandler : IRequestHandler<MessageCountQuery, QueryResult<MessageCountData>>
 {
     private readonly IEnqueuedMessages _enqueuedMessages;
 
@@ -30,14 +31,14 @@ public class MessageCountRequestHandler : IRequestHandler<MessageCountRequest, M
         _enqueuedMessages = enqueuedMessages;
     }
 
-    public async Task<MessageCountResult> Handle(MessageCountRequest request, CancellationToken cancellationToken)
+    public async Task<QueryResult<MessageCountData>> Handle(MessageCountQuery request, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
         var messageCount = await _enqueuedMessages.GetAvailableMessageCountAsync(request.ActorNumber).ConfigureAwait(false);
-        return new MessageCountResult(messageCount);
+        return new QueryResult<MessageCountData>(new MessageCountData(messageCount));
     }
 }
 
-public record MessageCountRequest(ActorNumber ActorNumber) : ICommand<MessageCountResult>;
+public record MessageCountQuery(ActorNumber ActorNumber) : IQuery<QueryResult<MessageCountData>>;
 
-public record MessageCountResult(int MessageCount);
+public record MessageCountData(int MessageCount);

--- a/source/Messaging.Infrastructure/OutgoingMessages/Peek/PeekConfiguration.cs
+++ b/source/Messaging.Infrastructure/OutgoingMessages/Peek/PeekConfiguration.cs
@@ -14,6 +14,7 @@
 
 using System;
 using MediatR;
+using Messaging.Application.Configuration.Queries;
 using Messaging.Application.OutgoingMessages;
 using Messaging.Application.OutgoingMessages.MessageCount;
 using Messaging.Application.OutgoingMessages.Peek;
@@ -27,7 +28,7 @@ internal static class PeekConfiguration
     {
         services.AddTransient<MessagePeeker>();
         services.AddTransient<IRequestHandler<PeekRequest, PeekResult>, PeekRequestHandler>();
-        services.AddTransient<IRequestHandler<MessageCountRequest, MessageCountResult>, MessageCountRequestHandler>();
+        services.AddTransient<IRequestHandler<MessageCountQuery, QueryResult<MessageCountData>>, MessageCountRequestHandler>();
         services.AddScoped<IEnqueuedMessages, EnqueuedMessages>();
         services.AddScoped(_ => bundleConfiguration);
 

--- a/source/Messaging.IntegrationTests/Application/OutgoingMessages/WhenMessageCountIsRequestedTests.cs
+++ b/source/Messaging.IntegrationTests/Application/OutgoingMessages/WhenMessageCountIsRequestedTests.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using Messaging.Application.OutgoingMessages.MessageCount;
 using Messaging.Domain.Actors;
 using Messaging.Domain.OutgoingMessages;
@@ -33,10 +32,10 @@ public class WhenMessageCountIsRequestedTests : TestBase
     [Fact]
     public async Task When_no_messages_are_available_return_zero()
     {
-        var result = await InvokeCommandAsync(CreateMessageCountRequest(SampleData.NewEnergySupplierNumber))
+        var result = await QueryAsync(CreateMessageCountRequest(SampleData.NewEnergySupplierNumber))
             .ConfigureAwait(false);
 
-        Assert.Equal(0, result.MessageCount);
+        Assert.Equal(0, result.Data!.MessageCount);
     }
 
     [Fact]
@@ -44,15 +43,15 @@ public class WhenMessageCountIsRequestedTests : TestBase
     {
         await GivenAMoveInTransactionHasBeenAccepted().ConfigureAwait(false);
 
-        var result = await InvokeCommandAsync(CreateMessageCountRequest(SampleData.NewEnergySupplierNumber))
+        var result = await QueryAsync(CreateMessageCountRequest(SampleData.NewEnergySupplierNumber))
             .ConfigureAwait(false);
 
-        Assert.Equal(1, result.MessageCount);
+        Assert.Equal(1, result.Data!.MessageCount);
     }
 
-    private static MessageCountRequest CreateMessageCountRequest(string actorNumber)
+    private static MessageCountQuery CreateMessageCountRequest(string actorNumber)
     {
-        return new MessageCountRequest(ActorNumber.Create(SampleData.NewEnergySupplierNumber));
+        return new MessageCountQuery(ActorNumber.Create(SampleData.NewEnergySupplierNumber));
     }
 
     private static IncomingMessageBuilder MessageBuilder()

--- a/source/Messaging.IntegrationTests/TestBase.cs
+++ b/source/Messaging.IntegrationTests/TestBase.cs
@@ -15,30 +15,24 @@
 using System;
 using System.Globalization;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using MediatR;
 using Messaging.Api.Configuration.Middleware.Correlation;
-using Messaging.Application.Configuration;
 using Messaging.Application.Configuration.Commands.Commands;
 using Messaging.Application.Configuration.DataAccess;
-using Messaging.Application.Configuration.TimeEvents;
+using Messaging.Application.Configuration.Queries;
 using Messaging.Application.Transactions.MoveIn;
 using Messaging.Infrastructure.Configuration;
 using Messaging.Infrastructure.Configuration.DataAccess;
-using Messaging.Infrastructure.Configuration.FeatureFlag;
 using Messaging.Infrastructure.Configuration.MessageBus;
 using Messaging.Infrastructure.Configuration.MessageBus.RemoteBusinessServices;
-using Messaging.Infrastructure.Configuration.Serialization;
-using Messaging.Infrastructure.OutgoingMessages.Peek;
-using Messaging.Infrastructure.Transactions;
-using Messaging.Infrastructure.Transactions.Aggregations;
 using Messaging.Infrastructure.Transactions.MoveIn;
 using Messaging.IntegrationTests.Fixtures;
 using Messaging.IntegrationTests.Infrastructure.Configuration.InternalCommands;
 using Messaging.IntegrationTests.TestDoubles;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Messaging.IntegrationTests
@@ -127,6 +121,11 @@ namespace Messaging.IntegrationTests
         protected Task<TResult> InvokeCommandAsync<TResult>(ICommand<TResult> command)
         {
             return GetService<IMediator>().Send(command);
+        }
+
+        protected Task<TResult> QueryAsync<TResult>(IQuery<TResult> query)
+        {
+            return GetService<IMediator>().Send(query, CancellationToken.None);
         }
 
         private static string CreateFakeServiceBusConnectionString()


### PR DESCRIPTION
## Description
Perform the MessageCount using a Query instead of a Command
This avoids a transaction lock on the SQl table while getting the message count
